### PR TITLE
Improve ingestion robustness and RMP update

### DIFF
--- a/backend/src/ingestion/rmpUpdate.ts
+++ b/backend/src/ingestion/rmpUpdate.ts
@@ -13,22 +13,33 @@ import { normalizeTeacherKey } from "../utils/normalizeTeacherKey.js";
 const schoolName = "University of California San Diego";
 
 export async function rmpUpdate(curTerm: string) {
-
   let searched = new Set<string>();
   const db: Db = await connectToDB();
-  let docs = await db.collection("courses").find({ Term: curTerm }).toArray();
+  const docs = await db.collection("courses").find({ Term: curTerm }).toArray();
+
+  // Build set of teacher name keys to query
+  for (const doc of docs) {
+    if (typeof doc.Teacher === 'string' && doc.Teacher.trim() !== '') {
+      const normalized = normalizeTeacherKey(doc.Teacher);
+      if (normalized.length > 0 && !searched.has(normalized)) {
+        searched.add(normalized);
+      }
+    }
+  }
+
+  if (searched.size === 0) {
+    return; // No teachers to look up
+  }
 
   const school = await searchSchool(schoolName);
 
-  // Add items to searched set 
-  for (const doc of docs) {
-
-    const normalized = normalizeTeacherKey(doc.Teacher);
-
-    if (normalized.length > 0 && !searched.has(normalized)) {
-      searched.add(normalized);
-    }
+  // If school not found, cannot fetch RMP data; exit early
+  if (!school || !Array.isArray(school) || school.length === 0) {
+    console.error(`School "${schoolName}" not found for RMP lookup`);
+    return;
   }
+
+  const schoolId = school[0].node.id;
 
   // Progress bar for visualization
   const rmpBar = new cliProgress.SingleBar(
@@ -41,13 +52,11 @@ export async function rmpUpdate(curTerm: string) {
 
   rmpBar.start(searched.size, 0, { name: "" });
 
-  // Call RMP API
+  // Call RMP API for each teacher
   for (const teacher of searched) {
-
     rmpBar.update({ name: teacher.trim() });
 
-    if (school !== undefined) {
-      const schoolId = school[0].node.id;
+    try {
       const search = await getProfessorRatingAtSchoolId(teacher, schoolId);
       const item: RMP = {
         avgRating: search.avgRating,
@@ -57,18 +66,19 @@ export async function rmpUpdate(curTerm: string) {
         nameKey: teacher.toLowerCase(),
       };
 
-      // Match course with RMP data
-      await db.collection("courses").updateOne(
+      // Update all course sections for this teacher
+      await db.collection("courses").updateMany(
         { nameKey: teacher },
         { $set: { rmp: item } }
-      )
-
+      );
+    } catch (error) {
+      console.error(`RMP lookup failed for teacher ${teacher}:`, error);
+      // Continue with next teacher
+    } finally {
+      rmpBar.increment();
     }
-
-    rmpBar.increment();
   }
 
   rmpBar.stop(); // Close TUI
-
   return;
 }

--- a/backend/src/ingestion/scrapeCurrentPage.ts
+++ b/backend/src/ingestion/scrapeCurrentPage.ts
@@ -73,7 +73,7 @@ export async function scrapeCurrentPage(subject: string, term: string, page: Pag
         nonTestBucket == "SE" ||
         nonTestBucket == "LA"
       ) {
-        if (current.Teacher.length <= 0) {
+        if (current.Teacher.length <= 0 && nestedRows[9]) {
           current.Teacher = nestedRows[9];
           current.nameKey = normalizeTeacherKey(nestedRows[9]);
         }
@@ -122,7 +122,7 @@ export async function scrapeCurrentPage(subject: string, term: string, page: Pag
           };
         }
       } else if (nonTestBucket === "IT") {
-        if (current.Teacher.length <= 0) {
+        if (current.Teacher.length <= 0 && nestedRows[9]) {
           current.Teacher = nestedRows[9];
           current.nameKey = normalizeTeacherKey(nestedRows[9]);
         }

--- a/backend/src/ingestion/startSearch.ts
+++ b/backend/src/ingestion/startSearch.ts
@@ -198,7 +198,7 @@ const SUBJECT_CODES: string[] = [
 ];
 
 export async function startSearch(term: string) {
-  // Browser intialization
+  // Browser initialization
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
   const db: Db = await connectToDB();
@@ -212,103 +212,71 @@ export async function startSearch(term: string) {
 
   subjectBar.start(SUBJECT_CODES.length, 0, { code: "" });
 
-  // Scrape all subjects
-  for (const code of SUBJECT_CODES) {
-    subjectBar.update({ code: code.trim() });
-    await page.goto(
-      "https://act.ucsd.edu/scheduleOfClasses/scheduleOfClassesStudent.htm",
-      { waitUntil: "networkidle2" },
-    );
-    await page.waitForSelector("#selectedSubjects");
+  try {
+    // Scrape all subjects
+    for (const code of SUBJECT_CODES) {
+      subjectBar.update({ code: code.trim() });
+      await page.goto(
+        "https://act.ucsd.edu/scheduleOfClasses/scheduleOfClassesStudent.htm",
+        { waitUntil: "networkidle2" },
+      );
+      await page.waitForSelector("#selectedSubjects");
 
-    // Skip if subject code DOM item DNE
-    const selected = await page.select("select#selectedSubjects", code);
-    if (selected.length <= 0) {
-      continue;
-    }
-
-    await page.click("#socFacSubmit");
-    await page.waitForSelector("#socDisplayCVO");
-
-    // To determine the max # of pages
-    const pages = await page.evaluate(() => {
-      return Array.from(
-        document.querySelectorAll<HTMLAnchorElement>('a[href*="page="]'),
-      )
-        .map((a) => a.getAttribute("href"))
-        .filter((h): h is string => h !== null);
-    });
-
-    let lastPage: number | null = null;
-
-    if (pages.length > 0) {
-      const lastHref = pages[pages.length - 1];
-      const pageParam = new URL(
-        lastHref,
-        "https://example.com",
-      ).searchParams.get("page");
-
-      lastPage = pageParam ? parseInt(pageParam, 10) : null;
-    }
-
-    lastPage = lastPage != null ? lastPage + 1 : 0;
-
-    let currentPage = 1;
-
-    while (currentPage < lastPage) {
-      // Scrapes contents of current page
-      let curPageContent = await scrapeCurrentPage(code, term, page);
-
-      if (curPageContent.length <= 0) {
-        break;
+      // Skip if subject code DOM item DNE
+      const selected = await page.select("select#selectedSubjects", code);
+      if (selected.length <= 0) {
+        continue;
       }
 
-      /*
-       * Connects, and inserts document to DB
-       * Note: Might block if you don't add IP to DB allowed list
-       */
-      await insertDB(db, curPageContent, "courses");
+      await page.click("#socFacSubmit");
+      await page.waitForSelector("#socDisplayCVO");
 
-      currentPage += 1;
+      // Process pages: always scrape the first page, then attempt to navigate to next pages
+      let currentPage = 1;
+      while (true) {
+        const curPageContent = await scrapeCurrentPage(code, term, page);
 
-      /**
-       * Checks if next page button exists
-       *
-       * @return true if exists, false if doesn't
-       */
-      let didClick = await page.evaluate((nextPage) => {
-        const links = Array.from(
-          document.querySelectorAll<HTMLAnchorElement>(
-            'a[href*="scheduleOfClassesStudentResult.htm?page="]',
-          ),
-        );
-
-        const nextLink = links.find(
-          (a) => a.textContent?.trim() === String(nextPage),
-        );
-
-        if (!nextLink) {
-          return false;
+        if (curPageContent.length > 0) {
+          await insertDB(db, curPageContent, "courses");
         }
 
-        nextLink.click();
-        return true;
-      }, currentPage);
+        // Attempt to go to the next page
+        const nextPage = currentPage + 1;
+        const didClick = await page.evaluate((targetPage) => {
+          const links = Array.from(
+            document.querySelectorAll<HTMLAnchorElement>(
+              'a[href*="scheduleOfClassesStudentResult.htm?page="]',
+            ),
+          );
 
-      // Waits for page to load if clicked
-      if (didClick) {
+          const nextLink = links.find(
+            (a) => a.textContent?.trim() === String(targetPage),
+          );
+
+          if (!nextLink) {
+            return false;
+          }
+
+          nextLink.click();
+          return true;
+        }, nextPage);
+
+        if (!didClick) {
+          break;
+        }
+
         await page.waitForNavigation({ waitUntil: "networkidle0" });
+        currentPage = nextPage;
       }
+
+      subjectBar.increment();
     }
 
-    subjectBar.increment();
+    await rmpUpdate(term);
+  } finally {
+    subjectBar.stop(); // Close TUI
+    await browser.close(); // Ensure browser closes even on errors
   }
-
-  await rmpUpdate(term);
-
-  subjectBar.stop(); // Close TUI
-
-  browser.close(); // To close the browser instance
 
   return;
 }


### PR DESCRIPTION
This PR includes several fixes to the ingestion backend:

- **startSearch**: Ensures the first page is always processed even when there is only one page. Added try/finally to guarantee browser cleanup on errors. Simplified pagination logic to always scrape the current page and break when next page link is not found.
- **scrapeCurrentPage**: Added guard against undefined teacher field to prevent runtime crashes when teacher name is missing.
- **rmpUpdate**: Changed from updateOne to updateMany so all course sections for a teacher receive RMP data. Added proper validation for teacher strings when building the search set. Added try/catch around RMP API calls to prevent one failure from aborting the entire batch. Added early exit if school lookup fails.

These changes improve reliability of the scheduled data ingestion process.