### PR TITLE
fix: correct field mapping for IT courses in scrapeCurrentPage

### DIFF
--- a/backend/src/ingestion/scrapeCurrentPage.ts
+++ b/backend/src/ingestion/scrapeCurrentPage.ts
@@ -129,8 +129,8 @@ export async function scrapeCurrentPage(subject: string, term: string, page: Pag
 
         current.Lecture = {
           Days: nestedRows[5],
-          Time: nestedRows[5],
-          Location: nestedRows[5],
+          Time: nestedRows[6],
+          Location: nestedRows[7] + " " + nestedRows[8],
         };
       }
     }


### PR DESCRIPTION
Fixes #18

### Changes
- Updated  to use correct indices for IT courses
- Changed  from  to 
- Changed  from  to 

### Impact
- IT (internship/independent study) courses will now have correct Days, Time, and Location data
- Fixes incorrect field mapping that was causing wrong data for IT-type courses