### PR TITLE
fix: remove static middleware pointing to missing public directory

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -32,7 +32,6 @@ app.use(
 );
 
 app.use(express.json());
-app.use(express.static(path.join(process.cwd(), "public")));
 app.use(requireApiSecret);
 
 app.use("/course", courseRouter);


### PR DESCRIPTION
Fixes #11

### Changes
- Removed `app.use(express.static(path.join(process.cwd(), "public")));` from `backend/src/app.ts`
- This line was causing ENOENT errors as there is no `public` directory in the backend

### Justification
- Frontend is served separately via Vercel (see `frontend/vercel.json`)
- The backend doesn't need to serve static files
- Removing this line prevents potential server crashes when the middleware tries to serve from non-existent folder