### PR TITLE
fix: remove trailing slash from CORS origin

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,7 +18,7 @@ const app = express();
 const allowedOrigins = [
   "https://tritonschedule.com",
   "https://triton-schedule-alpha.vercel.app",
-  "https://triton-schedule-jl29ml1fz-justin-wangs-projects-e5966906.vercel.app/",
+  "https://triton-schedule-jl29ml1fz-justin-wangs-projects-e5966906.vercel.app",
   "http://localhost:8080",
 ];
 


### PR DESCRIPTION
Fixes #10

Remove trailing slash from  in allowedOrigins array to fix CORS issues.