### PR TITLE
fix: remove static middleware for missing public directory

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,7 +18,7 @@ const app = express();
 const allowedOrigins = [
   "https://tritonschedule.com",
   "https://triton-schedule-alpha.vercel.app",
-  "https://triton-schedule-jl29ml1fz-justin-wangs-projects-e5966906.vercel.app/",
+  "https://triton-schedule-jl29ml1fz-justin-wangs-projects-e5966906.vercel.app",
   "http://localhost:8080",
 ];
 
@@ -32,7 +32,6 @@ app.use(
 );
 
 app.use(express.json());
-app.use(express.static(path.join(process.cwd(), "public")));
 app.use(requireApiSecret);
 
 app.use("/course", courseRouter);


### PR DESCRIPTION
Fixes #11

Remove `app.use(express.static(path.join(process.cwd(), "public")));` since the public directory doesn't exist and the frontend is served separately via Vercel.