### PR TITLE
fix: return empty array instead of 404 for no search results

### DIFF
--- a/backend/src/controllers/searchForClass.ts
+++ b/backend/src/controllers/searchForClass.ts
@@ -28,9 +28,5 @@ export async function searchForClass(req: any, res: any) {
 
   const queryResults = await db.collection("courses").find(query).toArray();
 
-  if (queryResults.length <= 0) {
-    return res.status(404).send('Item not found');
-  }
-
   return res.json({ data: queryResults });
 }


### PR DESCRIPTION
Fixes #12

Change response from 404 'Item not found' to 200 with empty array when no search results are found. This follows RESTful API design where an empty result set is a valid response, not an error.