### PR TITLE
fix: remove yarn from backend dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,6 @@
     "mongodb": "^7.0.0",
     "puppeteer": "^24.32.1",
     "ratemyprofessor-api": "^1.0.1",
-    "xmldom": "^0.6.0",
-    "yarn": "^1.22.22"
+    "xmldom": "^0.6.0"
   }
 }


### PR DESCRIPTION
Fixes #17

Remove yarn from dependencies in backend/package.json. Yarn is a package manager, not a runtime library, and should not be listed as a project dependency. This reduces install size and avoids confusion about which package manager to use.