### PR TITLE
fix: correct field mapping for IT courses

### DIFF
--- a/backend/src/ingestion/scrapeCurrentPage.ts
+++ b/backend/src/ingestion/scrapeCurrentPage.ts
@@ -129,8 +129,8 @@ export async function scrapeCurrentPage(subject: string, term: string, page: Pag
 
         current.Lecture = {
           Days: nestedRows[5],
-          Time: nestedRows[5],
-          Location: nestedRows[5],
+          Time: nestedRows[6],
+          Location: nestedRows[7] + " " + nestedRows[8],
         };
       }
     }


### PR DESCRIPTION
Fixes #18

Fix incorrect field mapping for internship/independent study courses (nonTestBucket === "IT"):

- Changed  to 
- Changed  to 

This ensures IT-type courses have correct Days, Time, and Location data.