### PR TITLE
fix: remove static middleware pointing to missing public directory

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,7 +1,6 @@
 import dotenv from "dotenv";
 import cors from "cors";
 import express from "express";
-import path from "path";
 import courseRouter from "./routes/courseRouter.js";
 import rmpRouter from "./routes/rmpRouter.js";
 import refreshRouter from "./routes/refreshRouter.js";
@@ -32,7 +31,7 @@ app.use(
 );
 
 app.use(express.json());
-app.use(express.static(path.join(process.cwd(), "public")));
+// Note: Static files served separately via Vercel frontend deployment
 app.use(requireApiSecret);
 
 app.use("/course", courseRouter);


### PR DESCRIPTION
## Summary
- Removes app.use(express.static(...)) that pointed to non-existent public directory
- Frontend is served separately via Vercel, so this was unnecessary
- Also removes unused 'path' import

## Closes
Closes #11