### PR TITLE
Fix #33: Add error handling to updateInformation endpoint

### DIFF
--- a/backend/src/controllers/updateInformation.ts
+++ b/backend/src/controllers/updateInformation.ts
@@ -1,19 +1,26 @@
 import { ingest } from "../ingestion/ingest.js";
 import { connectToDB } from "../services/connectToDB.js";
 import type { Db } from "mongodb";
+import type { Request, Response } from "express";
 
-export async function updateInformation(req: any, res: any) {
+export async function updateInformation(req: Request, res: Response) {
+  try {
+    const db: Db = await connectToDB();
 
-  const db: Db = await connectToDB();
+    const courseCollection = db.collection("courses");
+    const rmpCollection = db.collection("rmpData");
 
-  const courseCollection = db.collection("courses");
-  const rmpCollection = db.collection("rmpData");
+    await courseCollection.deleteMany({}); // Delete all existing courses for updates
+    await rmpCollection.deleteMany({}); // Delete all existing rmp data for updates
 
-  await courseCollection.deleteMany({}); // Delete all existing courses for updates
-  await rmpCollection.deleteMany({}); // Delete all existing rmp data for updates
+    await ingest(); // Updates
 
-  await ingest(); // Updates 
-
-  return res.status(200).send({ message: "Courses updated" });
-
+    return res.status(200).send({ message: "Courses updated" });
+  } catch (error) {
+    console.error("Error in updateInformation:", error);
+    return res.status(500).send({ 
+      error: "Failed to update courses", 
+      message: error instanceof Error ? error.message : "Unknown error" 
+    });
+  }
 }


### PR DESCRIPTION
## Description
Fixes issue #33 - the updateInformation endpoint has no error handling. If ingest() throws an error, the function never sends a response, causing request timeouts.

## Changes Made
- Wrapped ingest() call in try/catch block
- Returns 500 status with error message on failure
- Added console.error for debugging
- Replaced any types with proper Express Request/Response types

## Testing
- [ ] Tested endpoint with successful ingestion
- [ ] Verified error response is sent on failure

## Acceptance Criteria
- [x] Wrap ingest() call in try/catch
- [x] Return appropriate error status (500) with error message on failure
- [x] Add error logging for debugging

Closes #33