### PR TITLE
Fix #34: Correct IT course field mapping indices

### DIFF
--- a/backend/src/ingestion/scrapeCurrentPage.ts
+++ b/backend/src/ingestion/scrapeCurrentPage.ts
@@ -129,8 +129,8 @@ export async function scrapeCurrentPage(subject: string, term: string, page: Pag
 
         current.Lecture = {
           Days: nestedRows[5],
-          Time: nestedRows[5],
-          Location: nestedRows[5],
+          Time: nestedRows[6],
+          Location: nestedRows[7] + " " + nestedRows[8],
         };
       }
     }


### PR DESCRIPTION
## Description
Fixes issue #34 - the IT bucket field mapping used wrong indices in scrapeCurrentPage. Days, Time, and Location were all incorrectly set to nestedRows[5].

## Changes Made
- Changed Time from nestedRows[5] to nestedRows[6]
- Changed Location from nestedRows[5] to nestedRows[7] + nestedRows[8]
- Now matches the LE bucket pattern

## Testing
- [ ] Verify IT courses parse correctly with actual UCSD data

## Acceptance Criteria
- [x] Fix field indices for IT bucket Lecture mapping

Closes #34