### PR TITLE
Fix #39: Add rate limiting to /refresh endpoint

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "mongodb": "^7.0.0",
         "puppeteer": "^24.32.1",
         "ratemyprofessor-api": "^1.0.1",
@@ -3871,6 +3872,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -4629,9 +4648,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "mongodb": "^7.0.0",
     "puppeteer": "^24.32.1",
     "ratemyprofessor-api": "^1.0.1",

--- a/backend/src/middleware/rateLimitRefresh.ts
+++ b/backend/src/middleware/rateLimitRefresh.ts
@@ -1,0 +1,27 @@
+import rateLimit from "express-rate-limit";
+import type { Request, Response } from "express";
+
+// Rate limiter: max 1 request per 10 minutes per IP
+export const refreshRateLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000, // 10 minutes
+  max: 1,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: async (req: Request, res: Response) => {
+    res.setHeader("Retry-After", "600");
+    return res.status(429).json({
+      error: "Too many requests",
+      message: "Rate limit exceeded. The /refresh endpoint allows 1 request per 10 minutes.",
+      retryAfter: 600,
+    });
+  },
+  keyGenerator: (req: Request) => {
+    // Use Authorization header as the key so each API key has its own limit
+    const authHeader = req.headers.authorization ?? "";
+    if (authHeader.startsWith("Bearer ")) {
+      return authHeader.slice(7);
+    }
+    // Fall back to IP if no auth header
+    return req.ip ?? "unknown";
+  },
+});

--- a/backend/src/middleware/rateLimitRefresh.ts
+++ b/backend/src/middleware/rateLimitRefresh.ts
@@ -1,13 +1,13 @@
-import rateLimit from "express-rate-limit";
+import { ipKeyGenerator, rateLimit } from "express-rate-limit";
 import type { Request, Response } from "express";
 
-// Rate limiter: max 1 request per 10 minutes per IP
+// Rate limiter: max 1 request per 10 minutes per API key or IP
 export const refreshRateLimiter = rateLimit({
   windowMs: 10 * 60 * 1000, // 10 minutes
   max: 1,
   standardHeaders: true,
   legacyHeaders: false,
-  message: async (req: Request, res: Response) => {
+  handler: (_req: Request, res: Response) => {
     res.setHeader("Retry-After", "600");
     return res.status(429).json({
       error: "Too many requests",
@@ -22,6 +22,6 @@ export const refreshRateLimiter = rateLimit({
       return authHeader.slice(7);
     }
     // Fall back to IP if no auth header
-    return req.ip ?? "unknown";
+    return ipKeyGenerator(req.ip ?? "unknown");
   },
 });

--- a/backend/src/routes/refreshRouter.ts
+++ b/backend/src/routes/refreshRouter.ts
@@ -1,8 +1,9 @@
 import express from "express";
 import { updateInformation } from "../controllers/updateInformation.js";
+import { refreshRateLimiter } from "../middleware/rateLimitRefresh.js";
 
 const router = express.Router();
 
-router.get("/", updateInformation);
+router.get("/", refreshRateLimiter, updateInformation);
 
-export default router
+export default router;


### PR DESCRIPTION
## Description
Fixes issue #39 - The /refresh endpoint performs expensive operations but has no rate limiting, leading to potential resource exhaustion.

## Changes Made
Added express-rate-limit middleware to /refresh:
- Max 1 request per 10 minutes per API key
- Returns 429 Too Many Requests when limit exceeded
- Includes Retry-After header (600 seconds)
- Uses API key (Bearer token) as the rate limit key

## Files Added/Modified
- Created: 
- Modified: 

## Testing
- [x] TypeScript compiles without errors

## Acceptance Criteria
- [x] Apply rate limit to /refresh route
- [x] Return 429 with Retry-After header when limit hit
- [x] Document rate limit in API responses

Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to the refresh endpoint, restricting to 1 request per 10-minute window per API key to prevent abuse.

* **Bug Fixes & Improvements**
  * Rate-limited requests now return a 429 status with a `Retry-After` header indicating when to retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->