### PR TITLE
feat(backend): migrate catalog persistence to Supabase

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,3 @@
-MONGO_URI=mongodb://localhost:27017
-DB_NAME=tritonschedule
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_PUBLISHABLE_KEY=your_publishable_key_here
 SUPABASE_ANON_KEY=your_anon_key_here

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -157,6 +157,18 @@ set_env_key() {
   fi
 }
 
+comment_env_key() {
+  local file="$1"
+  local key="$2"
+
+  local tmp
+  tmp="$(mktemp "${file}.tmp.XXXXXX")"
+  ENV_KEY="$key" perl -0pe '
+    s/^[ \t]*\Q$ENV{ENV_KEY}\E[ \t]*=.*/"# disabled by setup: " . $&/mge
+  ' "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
 ensure_backend_secret() {
   local key="$1"
   local value
@@ -209,6 +221,31 @@ ensure_api_keys() {
   log "Set matching API keys in backend/.env and frontend/.env for local development."
 }
 
+ensure_no_mongo_env() {
+  local prohibited=(MONGO_URI DB_NAME)
+  local found=()
+
+  for key in "${prohibited[@]}"; do
+    if has_env_key "$key" "$BACKEND_ENV"; then
+      found+=("$key")
+    fi
+  done
+
+  if (( ${#found[@]} <= 0 )); then
+    return
+  fi
+
+  if (( CHECK_ONLY )); then
+    fail "Remove MongoDB env vars from backend/.env: ${found[*]}. This workspace uses Supabase."
+  fi
+
+  for key in "${found[@]}"; do
+    comment_env_key "$BACKEND_ENV" "$key"
+  done
+
+  warn "Commented out old MongoDB env vars in backend/.env: ${found[*]}"
+}
+
 status_env_value() {
   local key="$1"
   local status="$2"
@@ -239,6 +276,18 @@ sync_local_supabase_env() {
   fi
 
   log "Synced backend/.env from local Supabase status."
+}
+
+has_required_supabase_env() {
+  local required=(SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY)
+
+  for key in "${required[@]}"; do
+    if is_placeholder "$(env_value "$key" "$BACKEND_ENV")"; then
+      return 1
+    fi
+  done
+
+  return 0
 }
 
 is_local_supabase_url() {
@@ -279,7 +328,7 @@ start_local_supabase() {
 }
 
 validate_backend_env() {
-  local required=(MONGO_URI DB_NAME API_KEY JWT_SECRET)
+  local required=(SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY API_KEY JWT_SECRET)
   local missing=()
 
   for key in "${required[@]}"; do
@@ -292,7 +341,7 @@ validate_backend_env() {
     fail "Missing or placeholder required backend env values in backend/.env: ${missing[*]}"
   fi
 
-  local recommended=(SUPABASE_URL SUPABASE_PUBLISHABLE_KEY SUPABASE_ANON_KEY SUPABASE_SERVICE_ROLE_KEY DATABASE_URL DB_PASSWORD)
+  local recommended=(SUPABASE_PUBLISHABLE_KEY SUPABASE_ANON_KEY DATABASE_URL DB_PASSWORD)
   local missing_recommended=()
 
   for key in "${recommended[@]}"; do
@@ -305,7 +354,7 @@ validate_backend_env() {
     warn "Missing or placeholder recommended backend env values in backend/.env: ${missing_recommended[*]}"
   fi
 
-  log "Validated backend/.env for local development."
+  log "Validated backend/.env for Supabase local development."
 }
 
 validate_frontend_env() {
@@ -341,6 +390,11 @@ install_deps_for() {
     return
   fi
 
+  if [[ -d "$dir/node_modules" ]]; then
+    log "$label dependencies already installed; skipping."
+    return
+  fi
+
   log "Installing $label dependencies"
   if [[ -f "$dir/package-lock.json" ]]; then
     npm --prefix "$dir" --cache "$NPM_CACHE_DIR" ci
@@ -353,6 +407,12 @@ ensure_env_from_example "$BACKEND_ENV" "$ROOT_DIR/backend/.env.example" "backend
 ensure_env_from_example "$FRONTEND_ENV" "$ROOT_DIR/frontend/.env.example" "frontend"
 ensure_api_keys
 ensure_backend_secret JWT_SECRET
+ensure_no_mongo_env
+
+if ! has_required_supabase_env && (( ! CHECK_ONLY )) && [[ "$SUPABASE_MODE" != "skip" ]]; then
+  start_local_supabase
+  sync_local_supabase_env
+fi
 
 validate_backend_env
 validate_frontend_env


### PR DESCRIPTION
## Intent

The developer wanted the TritonSchedule backend reorganized according to researched TypeScript and Node best practices so compiled JavaScript would have a clean output structure without a nested dist/src directory, while improving development workflow, readability, and maintainability. They also wanted clarification about source map files and guidance on next development priorities. They then asked to complete the migration from MongoDB to Supabase by finding and replacing all MongoDB-related code and configuration and removing MongoDB dependencies. Finally, they wanted the Supabase migration changes preserved on a clearly named dedicated Git branch. They required robust, long-term maintainable choices, end-user-aligned E2E verification for bug fixes, strict attention to UI and engineering quality, no manual changes to generated changelogs, and no agent co-author attribution in commits.

## What Changed

- Replaced MongoDB catalog persistence with typed Supabase services, paginated queries, and atomic catalog replacement backed by secured schema migrations.
- Added local Supabase setup, teardown, and production backfill workflows, with updated environment templates and rollout documentation.
- Removed MongoDB dependencies and tracked backend dependencies, updated backend coverage for Supabase, and removed the frontend's hardcoded API key fallback.

## Risk Assessment

⚠️ Medium: No additional material issues were found, but this remains a broad datastore cutover whose production safety depends on applying all migrations and completing the documented pre-traffic catalog backfill.

## Testing

Backend and frontend automated suites passed; a clean local Supabase reset applied every migration, real authenticated APIs returned persisted catalog data, a failed replacement rolled back safely, and the rendered frontend displayed the seeded course correctly. MongoDB references and dependencies were absent, reviewer-visible API and screenshot evidence was captured, and all test-created worktree artifacts were cleaned.

- Evidence: Rendered frontend search backed by Supabase (local file: <code>/var/folders/zj/6pgp54yx64b1vrdp5_d9vl1r0000gn/T/no-mistakes-evidence/01KXMAHP9PQZCJR0R9RSRTV1G5/frontend-supabase-search.png</code>)
<details>
<summary>Evidence: Supabase API E2E and rollback transcript</summary>

```text
Authenticated health check
{"status":"ok","checks":{"server":{"ok":true},"env":{"ok":true,"missing":[]},"database":{"ok":true}},"uptimeSeconds":18,"responseTimeMs":21,"timestamp":"2026-07-16T02:19:00.164Z"}
HTTP 200

Active term persisted by Supabase RPC
{"Term":"FA26"}
HTTP 200

Flexible, case-insensitive course search backed by Supabase
{"data":[{"id":"06440ce4-73ec-45f3-aa71-6682f6bb16f1","Name":"CSE 101","Term":"FA26","Teacher":"Ada Lovelace","Lecture":{"Days":"MWF","Time":"10:00","Location":"CENTR 101"},"Labs":[],"Discussions":[],"Midterms":[],"Final":null,"nameKey":"ada lovelace","rmp":{"name":"Ada Lovelace","avgDiff":2.1,"nameKey":"ada lovelace","avgRating":4.8,"takeAgainPercent":97}}]}
HTTP 200

Professor lookup backed by Supabase
{"Data":[{"avgRating":4.8,"avgDiff":2.1,"takeAgainPercent":97,"name":"Ada Lovelace","nameKey":"ada lovelace"}]}
HTTP 200

API authentication remains enforced
{"Message":"Not Authorized"}
HTTP 401
Rejected invalid replacement: no valid courses to insert

Catalog after rejected replacement
{"Term":"FA26"}
HTTP 200

{"data":[{"id":"06440ce4-73ec-45f3-aa71-6682f6bb16f1","Name":"CSE 101","Term":"FA26","Teacher":"Ada Lovelace","Lecture":{"Days":"MWF","Time":"10:00","Location":"CENTR 101"},"Labs":[],"Discussions":[],"Midterms":[],"Final":null,"nameKey":"ada lovelace","rmp":{"name":"Ada Lovelace","avgDiff":2.1,"nameKey":"ada lovelace","avgRating":4.8,"takeAgainPercent":97}}]}
HTTP 200
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.lavish/ui-revamp-options.html` - branch carries 4 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (6731 file(s)) into the PR:
- 5b649a0 Remove hardcoded frontend API key fallback.
- 401e3d4 Add Supabase local config
- 6c53b78 Fix local environment setup
- 4f259d2 Add Supabase workspace setup scripts

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
1 warning still open:
- ⚠️ `.lavish/ui-revamp-options.html` - branch carries 4 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (6731 file(s)) into the PR:
- 5b649a0 Remove hardcoded frontend API key fallback.
- 401e3d4 Add Supabase local config
- 6c53b78 Fix local environment setup
- 4f259d2 Add Supabase workspace setup scripts

Push main to origin, or rebase your branch onto origin/main, before gating.

🔧 Fix applied.
1 warning still open:
- ⚠️ `.lavish/ui-revamp-options.html` - branch carries 4 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (6731 file(s)) into the PR:
- 5b649a0 Remove hardcoded frontend API key fallback.
- 401e3d4 Add Supabase local config
- 6c53b78 Fix local environment setup
- 4f259d2 Add Supabase workspace setup scripts

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed ✅</summary>

- 🚨 `backend/src/services/supabaseClient.ts:12` - Use the first non-empty key rather than nullish coalescing. Local Supabase versions may omit SECRET_KEY, and setup writes SUPABASE_SECRET_KEY=&#34;&#34; alongside a valid SERVICE_ROLE_KEY; the empty value is selected and the backend refuses to start. Apply the same fallback logic in the health check.
- 🚨 `supabase/migrations/20260608231631_initial_supabase_schema.sql:7` - Confirm and document a rollout backfill. These migrations create empty Supabase tables, while backend reads switch immediately and nothing copies the Mongo catalog or invokes refresh during deployment; without an external pre-traffic refresh, course searches are empty and /term returns 404.
- ⚠️ `scripts/setup.sh:363` - Do not skip dependency installation merely because node_modules exists. Existing worktrees can retain a stale directory without @supabase/supabase-js after this lockfile change, causing setup to report success while the backend cannot start; run npm ci or verify the lockfile installation state.
- ⚠️ `backend/src/services/supabaseRepository.ts:75` - Add a unique tie-breaker such as id to paginated ordering. Ordering only by name is unstable when multiple rows share a course name, so offset pages can omit or duplicate results across separate queries. Apply the same fix to professor pagination for consistency.
- ⚠️ `backend/src/controllers/updateInformation.ts:15` - Return a generic client-facing failure and keep the detailed error in server logs. Supabase/Postgres errors can contain schema, function, or operational details that should not be exposed in the HTTP response.

🔧 Fix: Harden Supabase migration rollout and runtime behavior
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat --name-status 0730e7f05171d6e8ff7c4b51293b610e666172f4..5160c813fa40ca82f9bd2fcaf54370d3f0813e41` and targeted source/config inspection</code>
- <code>`npm test -- --runInBand` in `backend`</code>
- <code>`npm test -- --run` in `frontend`</code>
- `npm run setup -- --skip-install --reset-db`
- <code>`npm run build` in `backend`</code>
- <code>Seeded a real FA26 catalog through compiled `replaceCatalog(...)`</code>
- <code>Ran the compiled backend and exercised authenticated `GET /health`, `GET /term`, `GET /course`, and `GET /rmp`, plus unauthenticated `GET /course`</code>
- `Submitted an invalid catalog replacement and re-queried the API to verify the previous catalog survived transaction rollback`
- <code>Launched the frontend, searched for `CSE 101` in a real browser, and captured the rendered Supabase-backed result with Puppeteer</code>
- <code>Searched project files for `mongodb`, `mongoose`, `MONGO_URI`, and `DB_NAME`, then ran `npm ls mongodb mongodb-memory-server --all`</code>
- <code>`npm run setdown -- --wipe`, stopped test servers, and removed generated environment, build, coverage, and Supabase branch artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
