### PR TITLE
Show class names and keep course actions in view

### DIFF
--- a/frontend/src/pages/SearchCourses.tsx
+++ b/frontend/src/pages/SearchCourses.tsx
@@ -140,6 +140,7 @@ export default function SearchCourses() {
   });
   const [activeTerm, setActiveTerm] = useState<string>("");
   const [selectedCourseId, setSelectedCourseId] = useState<string | null>(null);
+  const [isMobileDetailsOpen, setIsMobileDetailsOpen] = useState(false);
   const [selectedDiscussionIds, setSelectedDiscussionIds] = useState<Record<string, string>>({});
   const [selectedLabIds, setSelectedLabIds] = useState<Record<string, string>>({});
   const [lastFetchedQuery, setLastFetchedQuery] = useState(() => {
@@ -440,13 +441,19 @@ export default function SearchCourses() {
                 aria-label="Search courses"
                 placeholder="Course, instructor, or keyword"
                 value={searchQuery}
-                onChange={(event) => setSearchQuery(event.target.value)}
+                onChange={(event) => {
+                  setSearchQuery(event.target.value);
+                  setIsMobileDetailsOpen(false);
+                }}
                 className="h-14 rounded-lg border-border bg-white pl-12 pr-12 text-base shadow-none placeholder:text-muted-foreground/80 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/15"
               />
               {searchQuery && (
                 <button
                   type="button"
-                  onClick={() => setSearchQuery("")}
+                  onClick={() => {
+                    setSearchQuery("");
+                    setIsMobileDetailsOpen(false);
+                  }}
                   className="absolute right-3 top-1/2 flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   aria-label="Clear search"
                 >
@@ -505,7 +512,10 @@ export default function SearchCourses() {
                       <button
                         key={course.id}
                         type="button"
-                        onClick={() => setSelectedCourseId(course.id)}
+                        onClick={() => {
+                          setSelectedCourseId(course.id);
+                          setIsMobileDetailsOpen(true);
+                        }}
                         className={cn(
                           "relative grid w-full gap-2 px-5 py-4 text-left transition-colors hover:bg-muted/55 md:grid-cols-[1.05fr_.8fr_1.2fr_.85fr_.55fr] md:items-center md:gap-4",
                           isSelected && "bg-primary/[0.055] before:absolute before:inset-y-0 before:left-0 before:w-0.5 before:bg-primary"
@@ -514,9 +524,14 @@ export default function SearchCourses() {
                       >
                         <span className="min-w-0">
                           <span className="block truncate text-sm font-semibold text-foreground">
-                            {formatSectionCode(course, index)}
+                            {getCourseCode(course.name)}
                           </span>
-                          <span className="mt-0.5 block text-xs text-muted-foreground">Lecture</span>
+                          <span className="mt-0.5 block truncate text-xs text-foreground/70">
+                            {getCourseTitle(course.name)}
+                          </span>
+                          <span className="mt-0.5 block text-xs text-muted-foreground">
+                            {formatSectionCode(course, index)} · Lecture
+                          </span>
                         </span>
                         <span className="truncate text-sm text-foreground/80">{course.instructor}</span>
                         <span className="text-sm text-foreground/80">
@@ -537,11 +552,27 @@ export default function SearchCourses() {
           </div>
         </section>
 
-        <aside className="min-w-0 bg-[#fcfdff] px-5 py-6 sm:px-7 lg:px-8" aria-label="Selected course details">
+        <aside
+          className={cn(
+            "min-w-0 bg-[#fcfdff] px-5 py-6 sm:px-7 lg:px-8",
+            isMobileDetailsOpen
+              ? "fixed inset-x-0 bottom-0 top-16 z-40 overflow-y-auto xl:static xl:z-auto xl:block xl:overflow-visible"
+              : "hidden xl:block"
+          )}
+          aria-label="Selected course details"
+        >
           {selectedCourse ? (
-            <div className="mx-auto flex h-full w-full max-w-[520px] flex-col">
+            <div className="relative mx-auto flex min-h-full w-full max-w-[520px] flex-col xl:h-full xl:min-h-0">
+              <button
+                type="button"
+                onClick={() => setIsMobileDetailsOpen(false)}
+                className="absolute right-0 top-0 flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground xl:hidden"
+                aria-label="Close course details"
+              >
+                <X className="h-5 w-5" />
+              </button>
               <div>
-                <p className="text-sm font-semibold text-primary">
+                <p className="pr-12 text-sm font-semibold text-primary">
                   {formatSectionCode(selectedCourse, displayedCourses.indexOf(selectedCourse))}
                 </p>
                 <h1 className="mt-1 text-2xl font-semibold tracking-[-0.025em] text-foreground">
@@ -642,28 +673,30 @@ export default function SearchCourses() {
                 />
               </section>
 
-              <button
-                type="button"
-                disabled={
-                  addedCourseIds.has(selectedCourse.id) ||
-                  conflictingScheduledEvents.length > 0 ||
-                  candidateScheduleEvents.length === 0
-                }
-                onClick={() =>
-                  handleAddToCalendar(
-                    selectedCourse,
-                    selectedDiscussion,
-                    selectedLab
-                  )
-                }
-                className="mt-auto h-12 w-full rounded-md bg-primary px-5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
-              >
-                {addedCourseIds.has(selectedCourse.id)
-                  ? "Added to schedule"
-                  : conflictingScheduledEvents.length > 0
-                    ? "Resolve schedule conflict"
-                    : "Add section"}
-              </button>
+              <div className="sticky bottom-0 mt-auto -mx-5 border-t border-border bg-[#fcfdff] px-5 pb-6 pt-4 sm:-mx-7 sm:px-7 lg:-mx-8 lg:px-8 xl:static xl:mx-0 xl:border-0 xl:bg-transparent xl:px-0 xl:pb-0 xl:pt-0">
+                <button
+                  type="button"
+                  disabled={
+                    addedCourseIds.has(selectedCourse.id) ||
+                    conflictingScheduledEvents.length > 0 ||
+                    candidateScheduleEvents.length === 0
+                  }
+                  onClick={() =>
+                    handleAddToCalendar(
+                      selectedCourse,
+                      selectedDiscussion,
+                      selectedLab
+                    )
+                  }
+                  className="h-12 w-full rounded-md bg-primary px-5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+                >
+                  {addedCourseIds.has(selectedCourse.id)
+                    ? "Added to schedule"
+                    : conflictingScheduledEvents.length > 0
+                      ? "Resolve schedule conflict"
+                      : "Add section"}
+                </button>
+              </div>
             </div>
           ) : (
             <div className="mx-auto flex min-h-[420px] max-w-sm flex-col items-center justify-center text-center">

--- a/frontend/src/pages/SearchCourses.tsx
+++ b/frontend/src/pages/SearchCourses.tsx
@@ -478,7 +478,7 @@ export default function SearchCourses() {
             <div className="mt-4 overflow-hidden border-y border-border">
               {displayedCourses.length > 0 && !isBackendLoading && !isDebouncingSearch && (
                 <div className="hidden grid-cols-[1.05fr_.8fr_1.2fr_.85fr_.55fr] gap-4 border-b border-border px-5 py-3 text-xs font-medium text-muted-foreground md:grid">
-                  <span>Section</span>
+                  <span>Class</span>
                   <span>Instructor</span>
                   <span>Meeting</span>
                   <span>Location</span>
@@ -505,7 +505,7 @@ export default function SearchCourses() {
                 />
               ) : (
                 <div className="divide-y divide-border">
-                  {displayedCourses.map((course, index) => {
+                  {displayedCourses.map((course) => {
                     const isSelected = selectedCourse?.id === course.id;
                     const schedule = getCourseScheduleParts(course);
                     return (
@@ -528,9 +528,6 @@ export default function SearchCourses() {
                           </span>
                           <span className="mt-0.5 block truncate text-xs text-foreground/70">
                             {getCourseTitle(course.name)}
-                          </span>
-                          <span className="mt-0.5 block text-xs text-muted-foreground">
-                            {formatSectionCode(course, index)} · Lecture
                           </span>
                         </span>
                         <span className="truncate text-sm text-foreground/80">{course.instructor}</span>
@@ -556,8 +553,8 @@ export default function SearchCourses() {
           className={cn(
             "min-w-0 bg-[#fcfdff] px-5 py-6 sm:px-7 lg:px-8",
             isMobileDetailsOpen
-              ? "fixed inset-x-0 bottom-0 top-16 z-40 overflow-y-auto xl:static xl:z-auto xl:block xl:overflow-visible"
-              : "hidden xl:block"
+              ? "fixed inset-x-0 bottom-0 top-16 z-40 overflow-y-auto xl:sticky xl:top-16 xl:z-auto xl:block xl:h-[calc(100vh-4rem)] xl:self-start"
+              : "hidden xl:sticky xl:top-16 xl:block xl:h-[calc(100vh-4rem)] xl:self-start xl:overflow-y-auto"
           )}
           aria-label="Selected course details"
         >
@@ -573,7 +570,7 @@ export default function SearchCourses() {
               </button>
               <div>
                 <p className="pr-12 text-sm font-semibold text-primary">
-                  {formatSectionCode(selectedCourse, displayedCourses.indexOf(selectedCourse))}
+                  {getCourseCode(selectedCourse.name)}
                 </p>
                 <h1 className="mt-1 text-2xl font-semibold tracking-[-0.025em] text-foreground">
                   {getCourseTitle(selectedCourse.name)}
@@ -673,7 +670,7 @@ export default function SearchCourses() {
                 />
               </section>
 
-              <div className="sticky bottom-0 mt-auto -mx-5 border-t border-border bg-[#fcfdff] px-5 pb-6 pt-4 sm:-mx-7 sm:px-7 lg:-mx-8 lg:px-8 xl:static xl:mx-0 xl:border-0 xl:bg-transparent xl:px-0 xl:pb-0 xl:pt-0">
+              <div className="sticky bottom-0 mt-auto -mx-5 border-t border-border bg-[#fcfdff] px-5 pb-6 pt-4 sm:-mx-7 sm:px-7 lg:-mx-8 lg:px-8 xl:mx-0 xl:px-0 xl:pb-0">
                 <button
                   type="button"
                   disabled={
@@ -1298,15 +1295,6 @@ function getCourseTitle(name: string): string {
   const code = name.match(/\b[A-Z]{2,5}\s*\d{1,3}[A-Z]?\b/i)?.[0];
   const title = code ? name.replace(code, "").replace(/^\s*[-:]\s*/, "").trim() : name.trim();
   return title || getCourseCode(name);
-}
-
-function formatSectionCode(course: Course, index: number): string {
-  if (course.sectionCode) {
-    return course.sectionCode;
-  }
-
-  const code = getCourseCode(course.name);
-  return `${code}-${String(Math.max(index, 0) + 1).padStart(2, "0")}`;
 }
 
 function formatTerm(term: string): string {


### PR DESCRIPTION
## Summary

Show the class code and class title in each search result instead of the internal section identifier.

Keep selected course details and the Add section action within the browser viewport on desktop and mobile.

## Problem

Search rows emphasized internal identifiers such as `001-000-LE`, which are reused across many classes and do not identify the course.

The responsive grid also allowed the details column to stretch to the full results height.

On mobile the details appeared after the result list, and on desktop the Add section action could be pushed beneath the complete list.

## User impact

Students can identify each class directly from the result list.

They can inspect and add the selected class without scrolling through every remaining result, regardless of browser size.

## Testing

- `npm run lint`
- `npm test`
- `npm run build`
- Verified class labels, selection, scrolling, closing, and the persistent Add section action at mobile and desktop viewport sizes