### PR TITLE
Restrict subject code searches to exact matches

### DIFF
--- a/backend/src/services/supabaseRepository.ts
+++ b/backend/src/services/supabaseRepository.ts
@@ -13,6 +13,7 @@ import {
   buildLegacyCourses,
   buildLegacySections,
 } from "../ingestion/buildClassPlannerCatalog.js";
+import { SUBJECT_CODES } from "../ingestion/subjectCodes.js";
 import { normalizeTeacherKey } from "../utils/normalizeTeacherKey.js";
 import { connectToDB } from "./connectToDB.js";
 
@@ -50,6 +51,7 @@ const PAGE_SIZE = 1000;
 const CATALOG_BATCH_SIZE = 250;
 const PROFESSOR_COLUMNS = "name,name_key,avg_rating,avg_diff,take_again_percent,profile_url";
 const LEGACY_PROFESSOR_COLUMNS = "name,name_key,avg_rating,avg_diff,take_again_percent";
+const NORMALIZED_SUBJECT_CODES = new Set(SUBJECT_CODES.map((subjectCode) => subjectCode.trim()));
 
 function throwIfError(error: PostgrestError | null) {
   if (error) throw error;
@@ -90,6 +92,11 @@ function flexibleLikePattern(value: string) {
 
 function quotePostgrestValue(value: string) {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+export function exactSubjectCodeFromSearch(value: string): string | null {
+  const normalizedValue = value.trim().toUpperCase();
+  return NORMALIZED_SUBJECT_CODES.has(normalizedValue) ? normalizedValue : null;
 }
 
 const PRIMARY_INSTRUCTION_TYPES = new Set([
@@ -230,13 +237,19 @@ export async function searchCourses(course: string, term: string) {
       .range(offset, offset + PAGE_SIZE - 1);
 
     if (course.length > 0) {
-      const pattern = quotePostgrestValue(flexibleLikePattern(course));
-      query = query.or([
-        `module_code.ilike.${pattern}`,
-        `module_name.ilike.${pattern}`,
-        `course_title.ilike.${pattern}`,
-        `instructors_search.ilike.${pattern}`,
-      ].join(","));
+      const subjectCode = exactSubjectCodeFromSearch(course);
+
+      if (subjectCode) {
+        query = query.eq("subject_code", subjectCode);
+      } else {
+        const pattern = quotePostgrestValue(flexibleLikePattern(course));
+        query = query.or([
+          `module_code.ilike.${pattern}`,
+          `module_name.ilike.${pattern}`,
+          `course_title.ilike.${pattern}`,
+          `instructors_search.ilike.${pattern}`,
+        ].join(","));
+      }
     }
 
     if (term.length > 0) {

--- a/backend/tests/services/supabaseRepository.test.ts
+++ b/backend/tests/services/supabaseRepository.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
-import { mapOfferingToCourses } from "../../src/services/supabaseRepository.js";
+import {
+  exactSubjectCodeFromSearch,
+  mapOfferingToCourses,
+} from "../../src/services/supabaseRepository.js";
 
 const classMeeting = {
   meeting_ordinal: 0,
@@ -151,5 +154,18 @@ describe("mapOfferingToCourse", () => {
       Teacher: "Grace Hopper",
       SectionCode: "002-000-LE",
     });
+  });
+});
+
+describe("exactSubjectCodeFromSearch", () => {
+  it("recognizes subject-only searches regardless of case or surrounding whitespace", () => {
+    expect(exactSubjectCodeFromSearch("math")).toBe("MATH");
+    expect(exactSubjectCodeFromSearch(" CSE ")).toBe("CSE");
+  });
+
+  it("leaves course numbers and general keywords on the flexible search path", () => {
+    expect(exactSubjectCodeFromSearch("MATH 20C")).toBeNull();
+    expect(exactSubjectCodeFromSearch("mathematics")).toBeNull();
+    expect(exactSubjectCodeFromSearch("smith")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Restrict searches that exactly match a supported UC San Diego subject code to that subject.

Keep the existing flexible module, title, and instructor matching for all other searches.

## Problem

Subject-only queries used the same substring search as general keywords.

For example, `math` matched unrelated course titles containing “mathematics” instead of only MATH offerings.

## User impact

Searching for a department abbreviation now returns courses from that department without unrelated keyword matches.

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm test -- --runInBand`
- Queried the linked Supabase catalog for `math` and confirmed all 116 returned sections have subject MATH