### PR TITLE
Add section-aware TSS redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 ## Features
 
-- WIP
+- Search the active UCSD Class Planner catalog by course, title, or instructor and compare lecture, discussion, and lab choices against the current schedule.
+- Open the selected section combination in TSS when Class Planner supplies an official route that TritonSchedule can validate.
+- Add conflict-free course sections to a weekly calendar alongside custom events.
 
 ## Contributions
 
@@ -19,8 +21,7 @@
 Prerequisites:
 
 - Node.js 22 and npm
-- A MongoDB instance reachable through `MONGO_URI`
-- Docker and the Supabase CLI only when using the optional local Supabase stack
+- Access to a hosted Supabase project, or Docker and the Supabase CLI for the local Supabase stack
 
 Clone the project:
 
@@ -85,17 +86,15 @@ Keep `CRON_SECRET` server-only because it authorizes catalog refreshes.
 
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `MONGO_URI` | Backend | MongoDB connection string. |
-| `DB_NAME` | Backend | MongoDB database name. |
 | `API_KEY` | Backend | Bearer token accepted by the API and optional frontend build-time alias. |
 | `CRON_SECRET` | Backend | Server-only bearer token accepted by the catalog refresh endpoint. |
 | `JWT_SECRET` | Backend | Secret required by backend health validation. |
 | `PORT` | Optional | Backend listener port, defaulting to `3000`. |
 | `NODE_ENV` | Optional | Runtime environment; local `.env` loading is disabled in production. |
-| `SUPABASE_URL` | Optional | Hosted or local Supabase API URL used by workspace setup. |
+| `SUPABASE_URL` | Backend | Hosted or local Supabase API URL used for application data. |
 | `SUPABASE_PUBLISHABLE_KEY` | Optional | Supabase publishable key synchronized for local development. |
 | `SUPABASE_ANON_KEY` | Optional | Supabase anonymous key synchronized for local development. |
-| `SUPABASE_SERVICE_ROLE_KEY` | Optional | Supabase service-role key synchronized for local development. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Backend | Server-only Supabase service-role key used for application data. |
 | `DATABASE_URL` | Optional | Supabase PostgreSQL connection string synchronized for local development. |
 | `DB_PASSWORD` | Optional | Supabase PostgreSQL password used by local tooling. |
 | `VITE_API_BASE_URL` | Frontend | Primary backend URL; local development uses the Vite `/api` proxy. |
@@ -103,8 +102,8 @@ Keep `CRON_SECRET` server-only because it authorizes catalog refreshes.
 | `VITE_API_KEY` | Frontend | Bearer token embedded into the frontend build. |
 | `VITE_DEV` | Optional | Development flag available to the frontend. |
 
-The backend currently stores application data in MongoDB.
-The Supabase variables and [`supabase/config.toml`](supabase/config.toml) support the optional local Supabase workspace.
+The backend stores course, term, professor, and TSS routing data in Supabase.
+The remaining Supabase variables and [`supabase/config.toml`](supabase/config.toml) support the optional local Supabase workspace.
 
 ### Stopping local Supabase
 
@@ -123,6 +122,6 @@ npm run setdown -- --dry-run
 npm run setdown -- --all
 ```
 
-The setdown command does not stop MongoDB.
+The setdown command does not affect a hosted Supabase project.
 
 See [`backend/README.md`](backend/README.md) for backend structure, verification, and deployment details.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # TritonSchedule backend
 
-This package serves the TritonSchedule API and runs the course and Rate My Professors ingestion jobs.
+This package serves the TritonSchedule API and runs the Class Planner catalog and Rate My Professors ingestion jobs.
 
 ## Directory layout
 
@@ -42,6 +42,23 @@ npm run dev
 The repository-level `npm run dev` starts both the frontend and this backend in watch mode.
 Use the repository-level `npm run setup` first to create environment files, align the frontend and backend API keys, and install all workspace dependencies.
 The root [`README.md`](../README.md#environment-variables) documents every environment variable and the optional local Supabase setup.
+
+## Course search and TSS metadata
+
+`GET /course?course=<query>&term=<term>` returns one course record for each matching primary section.
+Lecture, discussion, and lab entries retain the display fields `Days`, `Time`, and `Location` and may include the following Class Planner identifiers:
+
+| Field | Meaning |
+| --- | --- |
+| `SectionId` | Class Planner section identifier. |
+| `SectionRef` | Term-qualified Class Planner section reference. |
+| `SectionCode` | Display code for the section. |
+| `EventPackageIds` | TSS event packages that contain the section. |
+
+Course records may also include `TssPackageUrls`, which maps event package IDs to their official TSS booking URLs for that primary section.
+When Class Planner provides a module route instead of event-package deep links, the record exposes it as `TssFallbackUrl`.
+These fields are optional because not every course or section combination has a valid TSS destination.
+The frontend enables **Open in TSS** only after it resolves one package shared by the selected lecture, discussion, and lab, or a valid module fallback, and validates the exact HTTPS `tss.ucsd.edu/fiori` route before opening a new tab.
 
 ## Verification
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -45,7 +45,8 @@ The root [`README.md`](../README.md#environment-variables) documents every envir
 
 ## Course search and TSS metadata
 
-`GET /course?course=<query>&term=<term>` returns one course record for each matching primary section.
+`GET /course?course=<query>&term=<term>` responds with `{ data: Course[] }` and returns one course record for each matching primary section.
+Primary sections include lecture, independent study, and seminar instruction types, including the Class Planner codes `LE`, `IN`, and `SE`.
 Lecture, discussion, and lab entries retain the display fields `Days`, `Time`, and `Location` and may include the following Class Planner identifiers:
 
 | Field | Meaning |

--- a/backend/src/ingestion/buildClassPlannerCatalog.ts
+++ b/backend/src/ingestion/buildClassPlannerCatalog.ts
@@ -32,6 +32,19 @@ const DAY_ORDER: Readonly<Record<string, number>> = {
   U: 7,
 };
 
+const PRIMARY_INSTRUCTION_TYPES = new Set([
+  "in",
+  "independent study",
+  "le",
+  "lecture",
+  "se",
+  "seminar",
+]);
+
+export function isPrimaryInstructionType(value: string): boolean {
+  return PRIMARY_INSTRUCTION_TYPES.has(value.trim().toLowerCase());
+}
+
 export function classPlannerSourceKey(course: ClassPlannerCourse): string {
   const sectionIds = course.sections
     .map(({ section_id }) => section_id)
@@ -183,9 +196,7 @@ export function buildLegacyCourses(
 ): Course[] {
   return courses.map((course) => {
     const primarySections = course.sections.filter(({ instruction_type_name }) =>
-      ["lecture", "independent study", "seminar"].includes(
-        instruction_type_name.toLowerCase(),
-      ),
+      isPrimaryInstructionType(instruction_type_name),
     );
     const discussions = course.sections.filter(({ instruction_type_name }) =>
       instruction_type_name.toLowerCase().includes("discussion"),

--- a/backend/src/ingestion/buildClassPlannerCatalog.ts
+++ b/backend/src/ingestion/buildClassPlannerCatalog.ts
@@ -262,12 +262,18 @@ export function buildLegacySections(
   sections: readonly ClassPlannerSection[],
 ): Section[] {
   return sections.flatMap((section) => {
+    const metadata = {
+      SectionId: section.section_id,
+      SectionRef: section.section_ref,
+      SectionCode: section.section_code,
+      EventPackageIds: section.event_package_ids,
+    };
     const classMeetings = section.meetings.filter(
       ({ meeting_kind }) => meeting_kind === "class",
     );
 
     if (classMeetings.length === 0) {
-      return [{ Days: "TBA", Time: "TBA", Location: "TBA" }];
+      return [{ Days: "TBA", Time: "TBA", Location: "TBA", ...metadata }];
     }
 
     const grouped = new Map<string, ClassPlannerMeeting[]>();
@@ -299,6 +305,7 @@ export function buildLegacySections(
         .join(""),
       Time: displayTime(meetings[0]!),
       Location: displayLocation(meetings[0]!),
+      ...metadata,
     }));
   });
 }

--- a/backend/src/ingestion/buildClassPlannerCatalog.ts
+++ b/backend/src/ingestion/buildClassPlannerCatalog.ts
@@ -41,6 +41,7 @@ const PRIMARY_INSTRUCTION_TYPES = new Set([
   "seminar",
 ]);
 
+/** Returns whether Class Planner identifies a section as primary instruction. */
 export function isPrimaryInstructionType(value: string): boolean {
   return PRIMARY_INSTRUCTION_TYPES.has(value.trim().toLowerCase());
 }

--- a/backend/src/models/Course.ts
+++ b/backend/src/models/Course.ts
@@ -14,6 +14,8 @@ export type Course = {
   Final: Section | null;
   nameKey: string;
   rmp: RMP | null;
+  /** Official TSS booking URLs keyed by event package ID for this primary section. */
   TssPackageUrls?: Record<string, string>;
+  /** Official module-level TSS route used when no event-package deep link exists. */
   TssFallbackUrl?: string;
 };

--- a/backend/src/models/Course.ts
+++ b/backend/src/models/Course.ts
@@ -14,4 +14,6 @@ export type Course = {
   Final: Section | null;
   nameKey: string;
   rmp: RMP | null;
+  TssPackageUrls?: Record<string, string>;
+  TssFallbackUrl?: string;
 };

--- a/backend/src/models/Section.ts
+++ b/backend/src/models/Section.ts
@@ -2,8 +2,12 @@ export type Section = {
   Days: string;
   Time: string;
   Location: string;
+  /** Class Planner section identifier. */
   SectionId?: string;
+  /** Term-qualified Class Planner section reference. */
   SectionRef?: string;
+  /** Class Planner display code for the section. */
   SectionCode?: string;
+  /** TSS event packages that contain this section. */
   EventPackageIds?: string[];
 };

--- a/backend/src/models/Section.ts
+++ b/backend/src/models/Section.ts
@@ -2,4 +2,8 @@ export type Section = {
   Days: string;
   Time: string;
   Location: string;
+  SectionId?: string;
+  SectionRef?: string;
+  SectionCode?: string;
+  EventPackageIds?: string[];
 };

--- a/backend/src/services/supabaseRepository.ts
+++ b/backend/src/services/supabaseRepository.ts
@@ -21,9 +21,20 @@ type MeetingRow = ClassPlannerMeeting & {
   meeting_ordinal: number;
 };
 
+type TssPackageRow = {
+  event_package_id: string;
+  tss_booking_url: string | null;
+};
+
+type TssModuleRouteRow = {
+  route_kind: "event_package" | "module";
+  tss_url: string;
+};
+
 type SectionRow = Omit<ClassPlannerSection, "event_package_ids" | "meetings"> & {
   id: number;
   class_planner_section_meetings: MeetingRow[];
+  tss_event_packages?: TssPackageRow[];
 };
 
 type OfferingRow = Omit<ClassPlannerCourse, "sections"> & {
@@ -31,6 +42,7 @@ type OfferingRow = Omit<ClassPlannerCourse, "sections"> & {
   source_key: string;
   instructors_search: string;
   class_planner_sections: SectionRow[];
+  tss_module_routes?: TssModuleRouteRow | TssModuleRouteRow[] | null;
 };
 
 type ProfessorRow = {
@@ -114,7 +126,8 @@ export function mapOfferingToCourses(
     sections: row.class_planner_sections
       .map((section): ClassPlannerSection => ({
         ...section,
-        event_package_ids: [],
+        event_package_ids: (section.tss_event_packages ?? [])
+          .map(({ event_package_id }) => event_package_id),
         meetings: section.class_planner_section_meetings
           .slice()
           .sort((left, right) => left.meeting_ordinal - right.meeting_ordinal),
@@ -127,6 +140,21 @@ export function mapOfferingToCourses(
   );
   const sectionChoices: Array<ClassPlannerSection | undefined> =
     primarySections.length > 0 ? primarySections : [undefined];
+  const tssPackageUrls = Object.fromEntries(
+    row.class_planner_sections.flatMap((section) =>
+      (section.tss_event_packages ?? []).flatMap((eventPackage) =>
+        eventPackage.tss_booking_url
+          ? [[eventPackage.event_package_id, eventPackage.tss_booking_url] as const]
+          : [],
+      ),
+    ),
+  );
+  const route = Array.isArray(row.tss_module_routes)
+    ? row.tss_module_routes[0]
+    : row.tss_module_routes;
+  const tssFallbackUrl = route?.route_kind === "module"
+    ? route.tss_url
+    : undefined;
 
   return sectionChoices.map((primarySection) => {
     const lectures = primarySection
@@ -134,6 +162,15 @@ export function mapOfferingToCourses(
       : [];
     const teacher = primarySection?.instructors[0] ?? row.instructors[0] ?? "";
     const nameKey = normalizeTeacherKey(teacher);
+    const relevantTssPackageUrls = primarySection
+      ? Object.fromEntries(
+          primarySection.event_package_ids.flatMap((packageId) =>
+            tssPackageUrls[packageId]
+              ? [[packageId, tssPackageUrls[packageId]] as const]
+              : [],
+          ),
+        )
+      : tssPackageUrls;
 
     return {
       ...baseCourse,
@@ -144,6 +181,8 @@ export function mapOfferingToCourses(
       SectionCode: primarySection?.section_code ?? row.module_code,
       nameKey,
       rmp: ratingsByNameKey.get(nameKey) ?? null,
+      TssPackageUrls: relevantTssPackageUrls,
+      TssFallbackUrl: tssFallbackUrl,
     };
   });
 }
@@ -214,6 +253,10 @@ export async function searchCourses(course: string, term: string) {
           waitlist_available,
           status,
           instructors,
+          tss_event_packages (
+            event_package_id,
+            tss_booking_url
+          ),
           class_planner_section_meetings (
             meeting_ordinal,
             meeting_kind,
@@ -231,6 +274,10 @@ export async function searchCourses(course: string, term: string) {
             is_remote,
             is_tba
           )
+        ),
+        tss_module_routes (
+          route_kind,
+          tss_url
         )
       `)
       .order("module_code", { ascending: true })

--- a/backend/src/services/supabaseRepository.ts
+++ b/backend/src/services/supabaseRepository.ts
@@ -12,6 +12,7 @@ import type { Term } from "../models/Term.js";
 import {
   buildLegacyCourses,
   buildLegacySections,
+  isPrimaryInstructionType,
 } from "../ingestion/buildClassPlannerCatalog.js";
 import { SUBJECT_CODES } from "../ingestion/subjectCodes.js";
 import { normalizeTeacherKey } from "../utils/normalizeTeacherKey.js";
@@ -111,12 +112,6 @@ export function exactSubjectCodeFromSearch(value: string): string | null {
   return NORMALIZED_SUBJECT_CODES.has(normalizedValue) ? normalizedValue : null;
 }
 
-const PRIMARY_INSTRUCTION_TYPES = new Set([
-  "independent study",
-  "lecture",
-  "seminar",
-]);
-
 export function mapOfferingToCourses(
   row: OfferingRow,
   ratingsByNameKey: ReadonlyMap<string, RMP> = new Map(),
@@ -136,7 +131,7 @@ export function mapOfferingToCourses(
   };
   const baseCourse = buildLegacyCourses(row.term_code, [classPlannerCourse])[0]!;
   const primarySections = classPlannerCourse.sections.filter((section) =>
-    PRIMARY_INSTRUCTION_TYPES.has(section.instruction_type_name.toLowerCase()),
+    isPrimaryInstructionType(section.instruction_type_name),
   );
   const sectionChoices: Array<ClassPlannerSection | undefined> =
     primarySections.length > 0 ? primarySections : [undefined];

--- a/backend/tests/ingestion/buildClassPlannerCatalog.test.ts
+++ b/backend/tests/ingestion/buildClassPlannerCatalog.test.ts
@@ -93,4 +93,21 @@ describe("buildLegacyCourses", () => {
       nameKey: "ada lovelace",
     });
   });
+
+  it("treats abbreviated seminar sections as primary sections", () => {
+    const seminar = classPlannerCourse(101, {
+      sections: [{
+        ...classPlannerCourse(101).sections[0]!,
+        instruction_type_name: "se",
+        section_code: "001-000-SE",
+      }],
+    });
+
+    const [result] = buildLegacyCourses("FA26", [seminar]);
+
+    expect(result?.Lecture).toMatchObject({
+      SectionCode: "001-000-SE",
+      EventPackageIds: ["1500000101"],
+    });
+  });
 });

--- a/backend/tests/ingestion/buildClassPlannerCatalog.test.ts
+++ b/backend/tests/ingestion/buildClassPlannerCatalog.test.ts
@@ -85,6 +85,10 @@ describe("buildLegacyCourses", () => {
         Days: "Tue",
         Time: "5:00pm-6:20pm",
         Location: "CENTR 101",
+        SectionId: "E 00000100",
+        SectionRef: "FA26:E 00000100",
+        SectionCode: "001-000-LE",
+        EventPackageIds: ["1500000100"],
       },
       nameKey: "ada lovelace",
     });

--- a/backend/tests/services/supabaseRepository.test.ts
+++ b/backend/tests/services/supabaseRepository.test.ts
@@ -97,8 +97,8 @@ describe("mapOfferingToCourse", () => {
           id: 9003,
           section_id: "E 00000003",
           section_ref: "FA26:E 00000003",
-          section_code: "002-000-LE",
-          instruction_type_name: "lecture",
+          section_code: "002-000-SE",
+          instruction_type_name: "se",
           capacity: 100,
           enrolled: 80,
           seats_available: 20,
@@ -188,7 +188,11 @@ describe("mapOfferingToCourse", () => {
     expect(result[1]).toMatchObject({
       id: "FA26:E 00000003",
       Teacher: "Grace Hopper",
-      SectionCode: "002-000-LE",
+      SectionCode: "002-000-SE",
+      Lecture: {
+        SectionRef: "FA26:E 00000003",
+        EventPackageIds: ["156500"],
+      },
       TssPackageUrls: {
         "156500": "https://tss.ucsd.edu/fiori#package-156500",
       },

--- a/backend/tests/services/supabaseRepository.test.ts
+++ b/backend/tests/services/supabaseRepository.test.ts
@@ -50,6 +50,10 @@ describe("mapOfferingToCourse", () => {
       prerequisites: [],
       restrictions: [],
       metadata_source: "UC San Diego course catalog",
+      tss_module_routes: {
+        route_kind: "event_package",
+        tss_url: "https://tss.ucsd.edu/fiori#representative",
+      },
       class_planner_sections: [
         {
           id: 9001,
@@ -65,6 +69,16 @@ describe("mapOfferingToCourse", () => {
           waitlist_available: null,
           status: "AC",
           instructors: ["Ada Lovelace"],
+          tss_event_packages: [
+            {
+              event_package_id: "156420",
+              tss_booking_url: "https://tss.ucsd.edu/fiori#package-156420",
+            },
+            {
+              event_package_id: "156421",
+              tss_booking_url: "https://tss.ucsd.edu/fiori#package-156421",
+            },
+          ],
           class_planner_section_meetings: [
             classMeeting,
             {
@@ -93,6 +107,12 @@ describe("mapOfferingToCourse", () => {
           waitlist_available: null,
           status: "AC",
           instructors: ["Grace Hopper"],
+          tss_event_packages: [
+            {
+              event_package_id: "156500",
+              tss_booking_url: "https://tss.ucsd.edu/fiori#package-156500",
+            },
+          ],
           class_planner_section_meetings: [
             { ...classMeeting, day_code: "M", day_name: "Monday" },
           ],
@@ -111,6 +131,12 @@ describe("mapOfferingToCourse", () => {
           waitlist_available: null,
           status: "AC",
           instructors: [],
+          tss_event_packages: [
+            {
+              event_package_id: "156420",
+              tss_booking_url: "https://tss.ucsd.edu/fiori#package-156420",
+            },
+          ],
           class_planner_section_meetings: [
             { ...classMeeting, day_code: "R", day_name: "Thursday" },
           ],
@@ -141,19 +167,75 @@ describe("mapOfferingToCourse", () => {
         Days: "Tue",
         Time: "5:00pm-6:20pm",
         Location: "CENTR 101",
+        SectionRef: "FA26:E 00000001",
+        EventPackageIds: ["156420", "156421"],
       },
       Lectures: [
         { Days: "Tue" },
         { Days: "Wed", Time: "7:00pm-8:00pm" },
       ],
-      Discussions: [{ Days: "Thu" }],
+      Discussions: [{
+        Days: "Thu",
+        SectionRef: "FA26:E 00000002",
+        EventPackageIds: ["156420"],
+      }],
+      TssPackageUrls: {
+        "156420": "https://tss.ucsd.edu/fiori#package-156420",
+        "156421": "https://tss.ucsd.edu/fiori#package-156421",
+      },
       rmp: rating,
     });
     expect(result[1]).toMatchObject({
       id: "FA26:E 00000003",
       Teacher: "Grace Hopper",
       SectionCode: "002-000-LE",
+      TssPackageUrls: {
+        "156500": "https://tss.ucsd.edu/fiori#package-156500",
+      },
     });
+  });
+
+  it("returns the module route only when no event-package deep link exists", () => {
+    const offering = {
+      id: 402,
+      source_key: "CSE-290:E 00000290",
+      instructors_search: "",
+      term_code: "FA26",
+      subject_code: "CSE",
+      course_code: "290",
+      module_code: "CSE-290",
+      module_name: "Independent Study",
+      course_title: null,
+      section_count: 1,
+      open_section_count: 1,
+      open_seat_count: 1,
+      waitlist_available_count: 0,
+      instruction_types: ["independent study"],
+      instructors: [],
+      availability_refresh_pending: false,
+      is_topic_course: false,
+      section_family: null,
+      subject_name: "Computer Science and Engineering",
+      academic_level: "UD",
+      matching_section_count: 1,
+      units_display: "4 units",
+      prerequisites: [],
+      restrictions: [],
+      metadata_source: "UC San Diego course catalog",
+      tss_module_routes: {
+        route_kind: "module",
+        tss_url: "https://tss.ucsd.edu/fiori#module-290",
+      },
+      class_planner_sections: [],
+    };
+
+    const [result] = mapOfferingToCourses(
+      offering as Parameters<typeof mapOfferingToCourses>[0],
+    );
+
+    expect(result?.TssFallbackUrl).toBe(
+      "https://tss.ucsd.edu/fiori#module-290",
+    );
   });
 });
 

--- a/frontend/src/data/sampleCourses.ts
+++ b/frontend/src/data/sampleCourses.ts
@@ -3,8 +3,11 @@ export interface DiscussionSection {
   name: string;
   time: string;
   location: string;
+  /** Term-qualified Class Planner section reference. */
   sectionRef?: string;
+  /** Class Planner display code for the section. */
   sectionCode?: string;
+  /** TSS event packages that contain this section. */
   eventPackageIds?: string[];
 }
 
@@ -24,10 +27,14 @@ export interface Course {
   color: string;
   lectureLocation?: string;
   lectureMeetings?: DiscussionSection[];
+  /** Term-qualified Class Planner reference for the primary section. */
   lectureSectionRef?: string;
+  /** TSS event packages that contain the primary section. */
   lectureEventPackageIds?: string[];
   sectionCode?: string;
+  /** Official TSS booking URLs keyed by event package ID. */
   tssPackageUrls?: Record<string, string>;
+  /** Official module-level TSS route when no package deep link exists. */
   tssFallbackUrl?: string;
   rmpRating?: number;
   rmpTakeAgain?: number;

--- a/frontend/src/data/sampleCourses.ts
+++ b/frontend/src/data/sampleCourses.ts
@@ -3,6 +3,9 @@ export interface DiscussionSection {
   name: string;
   time: string;
   location: string;
+  sectionRef?: string;
+  sectionCode?: string;
+  eventPackageIds?: string[];
 }
 
 export interface CourseExamSection {
@@ -21,7 +24,11 @@ export interface Course {
   color: string;
   lectureLocation?: string;
   lectureMeetings?: DiscussionSection[];
+  lectureSectionRef?: string;
+  lectureEventPackageIds?: string[];
   sectionCode?: string;
+  tssPackageUrls?: Record<string, string>;
+  tssFallbackUrl?: string;
   rmpRating?: number;
   rmpTakeAgain?: number;
   rmpAvgDifficulty?: number;

--- a/frontend/src/lib/tssBooking.ts
+++ b/frontend/src/lib/tssBooking.ts
@@ -8,6 +8,16 @@ const TSS_MODULE_HASH =
 
 type TssRouteKind = "event-package" | "module";
 
+/**
+ * Resolves the official TSS route for the complete section selection.
+ *
+ * Event-package routes must be shared by the lecture and every selected
+ * discussion or lab.
+ * Module fallbacks are accepted when Class Planner does not expose a package
+ * deep link.
+ * Returns `undefined` for incomplete selections, missing package metadata, or
+ * routes outside the recognized HTTPS `tss.ucsd.edu/fiori` shapes.
+ */
 export function resolveTssBookingUrl(
   course: Course,
   discussion?: DiscussionSection,

--- a/frontend/src/lib/tssBooking.ts
+++ b/frontend/src/lib/tssBooking.ts
@@ -1,0 +1,65 @@
+import type { Course, DiscussionSection } from "@/data/sampleCourses";
+
+export function resolveTssBookingUrl(
+  course: Course,
+  discussion?: DiscussionSection,
+  lab?: DiscussionSection,
+): string | undefined {
+  if ((course.discussionSections?.length ?? 0) > 0 && !discussion) {
+    return undefined;
+  }
+
+  if ((course.labSections?.length ?? 0) > 0 && !lab) {
+    return undefined;
+  }
+
+  if (course.tssFallbackUrl) {
+    return normalizeTssBookingUrl(course.tssFallbackUrl);
+  }
+
+  if (!course.lectureEventPackageIds?.length) {
+    return undefined;
+  }
+
+  const packageSets = [
+    course.lectureEventPackageIds,
+    discussion?.eventPackageIds,
+    lab?.eventPackageIds,
+  ].filter((packageIds): packageIds is string[] => packageIds !== undefined);
+
+  if (
+    packageSets.length === 0 ||
+    packageSets.some((packageIds) => packageIds.length === 0)
+  ) {
+    return undefined;
+  }
+
+  for (const packageId of packageSets[0]!) {
+    const isShared = packageSets
+      .slice(1)
+      .every((packageIds) => packageIds.includes(packageId));
+    const bookingUrl = course.tssPackageUrls?.[packageId];
+
+    if (isShared && bookingUrl) {
+      const normalizedUrl = normalizeTssBookingUrl(bookingUrl);
+
+      if (normalizedUrl) {
+        return normalizedUrl;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeTssBookingUrl(value: string): string | undefined {
+  try {
+    const url = new URL(value);
+
+    return url.protocol === "https:" && url.hostname === "tss.ucsd.edu"
+      ? url.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/frontend/src/lib/tssBooking.ts
+++ b/frontend/src/lib/tssBooking.ts
@@ -1,5 +1,13 @@
 import type { Course, DiscussionSection } from "@/data/sampleCourses";
 
+const TSS_ORIGIN = "https://tss.ucsd.edu";
+const TSS_EVENT_PACKAGE_HASH =
+  /^#ZUSModule-display\?TileType=MYMOD&\/Detail\/EventPackage\/SM\/[^/?#]+\/00000000\/0\/0\/0\/00000000-0000-0000-0000-000000000000\/[^/?#]+\/[^/?#]+\/[^/?#]+\/\?$/;
+const TSS_MODULE_HASH =
+  /^#YSchedule-view&\/YUCSD_CON_MODULE\(AcademicYear='[^']+',AcademicPeriod='[^']+',ModuleID='[^']+'\)\?layout=MidColumnFullScreen$/;
+
+type TssRouteKind = "event-package" | "module";
+
 export function resolveTssBookingUrl(
   course: Course,
   discussion?: DiscussionSection,
@@ -14,23 +22,16 @@ export function resolveTssBookingUrl(
   }
 
   if (course.tssFallbackUrl) {
-    return normalizeTssBookingUrl(course.tssFallbackUrl);
-  }
-
-  if (!course.lectureEventPackageIds?.length) {
-    return undefined;
+    return normalizeTssBookingUrl(course.tssFallbackUrl, "module");
   }
 
   const packageSets = [
     course.lectureEventPackageIds,
-    discussion?.eventPackageIds,
-    lab?.eventPackageIds,
-  ].filter((packageIds): packageIds is string[] => packageIds !== undefined);
+    ...(discussion ? [discussion.eventPackageIds] : []),
+    ...(lab ? [lab.eventPackageIds] : []),
+  ];
 
-  if (
-    packageSets.length === 0 ||
-    packageSets.some((packageIds) => packageIds.length === 0)
-  ) {
+  if (!packageSets.every(hasPackageIds)) {
     return undefined;
   }
 
@@ -41,7 +42,7 @@ export function resolveTssBookingUrl(
     const bookingUrl = course.tssPackageUrls?.[packageId];
 
     if (isShared && bookingUrl) {
-      const normalizedUrl = normalizeTssBookingUrl(bookingUrl);
+      const normalizedUrl = normalizeTssBookingUrl(bookingUrl, "event-package");
 
       if (normalizedUrl) {
         return normalizedUrl;
@@ -52,11 +53,26 @@ export function resolveTssBookingUrl(
   return undefined;
 }
 
-function normalizeTssBookingUrl(value: string): string | undefined {
+function hasPackageIds(packageIds: string[] | undefined): packageIds is string[] {
+  return Boolean(packageIds?.length);
+}
+
+function normalizeTssBookingUrl(
+  value: string,
+  routeKind: TssRouteKind,
+): string | undefined {
   try {
     const url = new URL(value);
+    const routePattern = routeKind === "event-package"
+      ? TSS_EVENT_PACKAGE_HASH
+      : TSS_MODULE_HASH;
 
-    return url.protocol === "https:" && url.hostname === "tss.ucsd.edu"
+    return url.origin === TSS_ORIGIN &&
+        url.pathname === "/fiori" &&
+        url.search === "" &&
+        url.username === "" &&
+        url.password === "" &&
+        routePattern.test(url.hash)
       ? url.toString()
       : undefined;
   } catch {

--- a/frontend/src/pages/SearchCourses.tsx
+++ b/frontend/src/pages/SearchCourses.tsx
@@ -107,7 +107,7 @@ function createApiRequestInit(signal: AbortSignal): RequestInit {
 }
 
 export default function SearchCourses() {
-  const SEARCH_RESULTS_CACHE_KEY = "searchCourseResultsCache";
+  const SEARCH_RESULTS_CACHE_KEY = "searchCourseResultsCache:v2";
   const [searchQuery, setSearchQuery] = useState(() =>
     sessionStorage.getItem("searchCoursesQuery") ?? ""
   );

--- a/frontend/src/pages/SearchCourses.tsx
+++ b/frontend/src/pages/SearchCourses.tsx
@@ -21,6 +21,7 @@ import { CalendarEvent, Weekday } from "@/types/calendar";
 import { cn } from "@/lib/utils";
 import { getProfessorProfileUrl, normalizeProfessorProfileUrl } from "@/lib/professorProfile";
 import { findConflictingEvents, hasScheduleConflict } from "@/lib/scheduleConflicts";
+import { resolveTssBookingUrl } from "@/lib/tssBooking";
 import { toast } from "sonner";
 
 const API_KEY =
@@ -351,6 +352,13 @@ export default function SearchCourses() {
     [selectedCourse, selectedLabIds, availableLabSections]
   );
 
+  const selectedTssUrl = useMemo(
+    () => selectedCourse
+      ? resolveTssBookingUrl(selectedCourse, selectedDiscussion, selectedLab)
+      : undefined,
+    [selectedCourse, selectedDiscussion, selectedLab]
+  );
+
   const candidateLabEvents = useMemo(
     () => selectedCourse && selectedLab
       ? sectionScheduleToEvents(
@@ -673,28 +681,50 @@ export default function SearchCourses() {
               </div>
 
               <div className="-mx-5 shrink-0 border-t border-border bg-[#fcfdff] px-5 pb-6 pt-4 sm:-mx-7 sm:px-7 lg:-mx-8 lg:px-8 xl:mx-0 xl:px-0 xl:pb-0">
-                <button
-                  type="button"
-                  disabled={
-                    addedCourseIds.has(selectedCourse.id) ||
-                    conflictingScheduledEvents.length > 0 ||
-                    candidateScheduleEvents.length === 0
-                  }
-                  onClick={() =>
-                    handleAddToCalendar(
-                      selectedCourse,
-                      selectedDiscussion,
-                      selectedLab
-                    )
-                  }
-                  className="h-12 w-full rounded-md bg-primary px-5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
-                >
-                  {addedCourseIds.has(selectedCourse.id)
-                    ? "Added to schedule"
-                    : conflictingScheduledEvents.length > 0
-                      ? "Resolve schedule conflict"
-                      : "Add section"}
-                </button>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {selectedTssUrl ? (
+                    <a
+                      href={selectedTssUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-border bg-white px-5 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      Open in TSS
+                    </a>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled
+                      className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-border bg-muted px-5 text-sm font-semibold text-muted-foreground"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      TSS link unavailable
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    disabled={
+                      addedCourseIds.has(selectedCourse.id) ||
+                      conflictingScheduledEvents.length > 0 ||
+                      candidateScheduleEvents.length === 0
+                    }
+                    onClick={() =>
+                      handleAddToCalendar(
+                        selectedCourse,
+                        selectedDiscussion,
+                        selectedLab
+                      )
+                    }
+                    className="h-12 w-full rounded-md bg-primary px-5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
+                  >
+                    {addedCourseIds.has(selectedCourse.id)
+                      ? "Added to schedule"
+                      : conflictingScheduledEvents.length > 0
+                        ? "Resolve schedule conflict"
+                        : "Add section"}
+                  </button>
+                </div>
               </div>
             </div>
           ) : (
@@ -1366,6 +1396,10 @@ type BackendSection = {
   Days?: string;
   Time?: string;
   Location?: string;
+  SectionId?: string;
+  SectionRef?: string;
+  SectionCode?: string;
+  EventPackageIds?: string[];
 };
 
 type BackendCourse = {
@@ -1391,6 +1425,8 @@ type BackendCourse = {
   midterms?: BackendSection[];
   Final?: BackendSection | null;
   final?: BackendSection | null;
+  TssPackageUrls?: Record<string, string>;
+  TssFallbackUrl?: string;
 };
 
 type BackendResponse = BackendCourse[] | { data?: BackendCourse[] };
@@ -1440,8 +1476,15 @@ function mapBackendCourseToCourse(course: BackendCourse, index: number): Course 
       name: `Lecture meeting ${meetingIndex + 1}`,
       time: `${meeting.Days ?? ""} ${meeting.Time ?? ""}`.trim() || "TBA",
       location: meeting.Location?.trim() || "TBA",
+      sectionRef: meeting.SectionRef,
+      sectionCode: meeting.SectionCode,
+      eventPackageIds: meeting.EventPackageIds,
     })),
+    lectureSectionRef: lecture?.SectionRef,
+    lectureEventPackageIds: lecture?.EventPackageIds,
     sectionCode: course.SectionCode,
+    tssPackageUrls: course.TssPackageUrls,
+    tssFallbackUrl: course.TssFallbackUrl,
     rmpRating:
       Number.isFinite(avgRating) && avgRating > 0
         ? avgRating
@@ -1453,15 +1496,21 @@ function mapBackendCourseToCourse(course: BackendCourse, index: number): Course 
     rmpProfileUrl: normalizeProfessorProfileUrl(rmp?.profileUrl),
     discussionSections: discussions.map((section, sectionIndex) => ({
       id: `${index}-${sectionIndex}`,
-      name: `Discussion ${sectionIndex + 1}`,
+      name: section.SectionCode ?? `Discussion ${sectionIndex + 1}`,
       time: `${section.Days ?? ""} ${section.Time ?? ""}`.trim() || "TBA",
       location: section.Location?.trim() || "TBA",
+      sectionRef: section.SectionRef,
+      sectionCode: section.SectionCode,
+      eventPackageIds: section.EventPackageIds,
     })),
     labSections: labs.map((section, sectionIndex) => ({
       id: `${index}-lab-${sectionIndex}`,
-      name: `Lab ${sectionIndex + 1}`,
+      name: section.SectionCode ?? `Lab ${sectionIndex + 1}`,
       time: `${section.Days ?? ""} ${section.Time ?? ""}`.trim() || "TBA",
       location: section.Location?.trim() || "TBA",
+      sectionRef: section.SectionRef,
+      sectionCode: section.SectionCode,
+      eventPackageIds: section.EventPackageIds,
     })),
     midtermSections: midterms
       .filter((midterm) => {

--- a/frontend/src/test/calendarContext.test.tsx
+++ b/frontend/src/test/calendarContext.test.tsx
@@ -51,7 +51,7 @@ describe("CalendarContext", () => {
     const newEvent = {
       id: "2",
       title: "New Event",
-      dayOfWeek: "Tuesday",
+      dayOfWeek: "Tue" as const,
       startTime: "10:00",
       endTime: "11:00",
       color: "#00ff00",
@@ -75,7 +75,7 @@ describe("CalendarContext", () => {
     const event = {
       id: "3",
       title: "Original Title",
-      dayOfWeek: "Wednesday",
+      dayOfWeek: "Wed" as const,
       startTime: "11:00",
       endTime: "12:00",
       color: "#0000ff",
@@ -101,7 +101,7 @@ describe("CalendarContext", () => {
     const event = {
       id: "4",
       title: "To Delete",
-      dayOfWeek: "Thursday",
+      dayOfWeek: "Thu" as const,
       startTime: "13:00",
       endTime: "14:00",
       color: "#ffff00",
@@ -130,7 +130,7 @@ describe("CalendarContext", () => {
       result.current.addEvent({
         id: "5",
         title: "Event 1",
-        dayOfWeek: "Friday",
+        dayOfWeek: "Fri",
         startTime: "14:00",
         endTime: "15:00",
         color: "#ff00ff",
@@ -139,7 +139,7 @@ describe("CalendarContext", () => {
       result.current.addEvent({
         id: "6",
         title: "Event 2",
-        dayOfWeek: "Friday",
+        dayOfWeek: "Fri",
         startTime: "15:00",
         endTime: "16:00",
         color: "#00ffff",

--- a/frontend/src/test/courseRow.test.tsx
+++ b/frontend/src/test/courseRow.test.tsx
@@ -10,10 +10,9 @@ const mockCourse: Course = {
   description: "Introduction to programming",
   color: "#ff0000",
   discussionSections: [
-    { id: "D1", section: "A", time: "MWF 10am", location: "Room 101" },
-    { id: "D2", section: "B", time: "MWF 11am", location: "Room 102" },
+    { id: "D1", name: "A", time: "MWF 10am", location: "Room 101" },
+    { id: "D2", name: "B", time: "MWF 11am", location: "Room 102" },
   ],
-  examSections: [],
   rmpRating: 4.5,
   rmpTakeAgain: 80,
   rmpAvgDifficulty: 3.0,
@@ -133,8 +132,8 @@ describe("CourseRow", () => {
       instructor: "Dr. Johnson",
       description: "Advanced data structures",
       color: "#00ff00",
+      schedule: "",
       discussionSections: [],
-      examSections: [],
     };
 
     render(
@@ -156,8 +155,8 @@ describe("CourseRow", () => {
       instructor: "Dr. Williams",
       description: "Algorithm design and analysis",
       color: "#0000ff",
+      schedule: "",
       discussionSections: [],
-      examSections: [],
     };
 
     render(

--- a/frontend/src/test/tssBooking.test.ts
+++ b/frontend/src/test/tssBooking.test.ts
@@ -78,9 +78,12 @@ describe("resolveTssBookingUrl", () => {
     expect(resolveTssBookingUrl(course)).toBeUndefined();
   });
 
-  it.each([undefined, []])(
+  it.each([
+    { eventPackageIds: undefined },
+    { eventPackageIds: [] },
+  ])(
     "requires package membership metadata from the selected section",
-    (eventPackageIds) => {
+    ({ eventPackageIds }) => {
       expect(resolveTssBookingUrl(course, {
         ...discussion,
         eventPackageIds,

--- a/frontend/src/test/tssBooking.test.ts
+++ b/frontend/src/test/tssBooking.test.ts
@@ -11,6 +11,15 @@ const discussion: DiscussionSection = {
   eventPackageIds: ["156420", "157065"],
 };
 
+const eventPackageUrl =
+  "https://tss.ucsd.edu/fiori#ZUSModule-display?TileType=MYMOD&" +
+  "/Detail/EventPackage/SM/14433/00000000/0/0/0/" +
+  "00000000-0000-0000-0000-000000000000/156420/2026/2/?";
+const moduleUrl =
+  "https://tss.ucsd.edu/fiori#YSchedule-view&/" +
+  "YUCSD_CON_MODULE(AcademicYear='2026',AcademicPeriod='2',ModuleID='14433')" +
+  "?layout=MidColumnFullScreen";
+
 const course: Course = {
   id: "FA26:E 00001997",
   name: "PHYS 002A: Physics-Mechanics",
@@ -22,16 +31,14 @@ const course: Course = {
   lectureEventPackageIds: ["156420", "156421"],
   discussionSections: [discussion],
   tssPackageUrls: {
-    "156420": "https://tss.ucsd.edu/fiori#package-156420",
-    "156421": "https://tss.ucsd.edu/fiori#package-156421",
+    "156420": eventPackageUrl,
+    "156421": eventPackageUrl.replace("/156420/", "/156421/"),
   },
 };
 
 describe("resolveTssBookingUrl", () => {
   it("returns the event package shared by every selected section", () => {
-    expect(resolveTssBookingUrl(course, discussion)).toBe(
-      "https://tss.ucsd.edu/fiori#package-156420",
-    );
+    expect(resolveTssBookingUrl(course, discussion)).toBe(eventPackageUrl);
   });
 
   it("does not open a different package when the combination is invalid", () => {
@@ -45,13 +52,23 @@ describe("resolveTssBookingUrl", () => {
     expect(resolveTssBookingUrl(course)).toBeUndefined();
   });
 
+  it.each([undefined, []])(
+    "requires package membership metadata from the selected section",
+    (eventPackageIds) => {
+      expect(resolveTssBookingUrl(course, {
+        ...discussion,
+        eventPackageIds,
+      })).toBeUndefined();
+    },
+  );
+
   it("uses a module route when Class Planner has no event-package route", () => {
     expect(resolveTssBookingUrl({
       ...course,
       discussionSections: [],
       lectureEventPackageIds: undefined,
-      tssFallbackUrl: "https://tss.ucsd.edu/fiori#module-14433",
-    })).toBe("https://tss.ucsd.edu/fiori#module-14433");
+      tssFallbackUrl: moduleUrl,
+    })).toBe(moduleUrl);
   });
 
   it("rejects links outside the official TSS origin", () => {
@@ -61,5 +78,31 @@ describe("resolveTssBookingUrl", () => {
         "156420": "https://example.com/not-tss",
       },
     }, discussion)).toBeUndefined();
+  });
+
+  it.each([
+    eventPackageUrl.replace("/fiori#", "/unrelated#"),
+    "https://tss.ucsd.edu/fiori#unrecognized-route",
+    eventPackageUrl.replace("tss.ucsd.edu", "tss.ucsd.edu:444"),
+    eventPackageUrl.replace("/fiori#", "/fiori?redirect=true#"),
+    eventPackageUrl.replace("https://", "https://user@"),
+  ])("rejects malformed TSS routes", (tssUrl) => {
+    expect(resolveTssBookingUrl({
+      ...course,
+      tssPackageUrls: { "156420": tssUrl },
+    }, discussion)).toBeUndefined();
+  });
+
+  it.each([
+    moduleUrl.replace("/fiori#", "/unrelated#"),
+    "https://tss.ucsd.edu/fiori#unrecognized-route",
+    moduleUrl.replace("tss.ucsd.edu", "tss.ucsd.edu:444"),
+    eventPackageUrl,
+  ])("rejects malformed module fallback routes", (tssFallbackUrl) => {
+    expect(resolveTssBookingUrl({
+      ...course,
+      discussionSections: [],
+      tssFallbackUrl,
+    })).toBeUndefined();
   });
 });

--- a/frontend/src/test/tssBooking.test.ts
+++ b/frontend/src/test/tssBooking.test.ts
@@ -11,6 +11,15 @@ const discussion: DiscussionSection = {
   eventPackageIds: ["156420", "157065"],
 };
 
+const lab: DiscussionSection = {
+  id: "lab-1",
+  name: "001-001-LA",
+  time: "Thu 2:00pm-4:50pm",
+  location: "MAYER 2306",
+  sectionRef: "FA26:E 00001999",
+  eventPackageIds: ["156420", "158000"],
+};
+
 const eventPackageUrl =
   "https://tss.ucsd.edu/fiori#ZUSModule-display?TileType=MYMOD&" +
   "/Detail/EventPackage/SM/14433/00000000/0/0/0/" +
@@ -39,6 +48,23 @@ const course: Course = {
 describe("resolveTssBookingUrl", () => {
   it("returns the event package shared by every selected section", () => {
     expect(resolveTssBookingUrl(course, discussion)).toBe(eventPackageUrl);
+  });
+
+  it("resolves the exact package shared by the lecture, discussion, and lab", () => {
+    expect(resolveTssBookingUrl({
+      ...course,
+      labSections: [lab],
+    }, discussion, lab)).toBe(eventPackageUrl);
+  });
+
+  it("does not resolve a package when the selected lab breaks the intersection", () => {
+    expect(resolveTssBookingUrl({
+      ...course,
+      labSections: [lab],
+    }, discussion, {
+      ...lab,
+      eventPackageIds: ["158000"],
+    })).toBeUndefined();
   });
 
   it("does not open a different package when the combination is invalid", () => {

--- a/frontend/src/test/tssBooking.test.ts
+++ b/frontend/src/test/tssBooking.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { Course, DiscussionSection } from "@/data/sampleCourses";
+import { resolveTssBookingUrl } from "@/lib/tssBooking";
+
+const discussion: DiscussionSection = {
+  id: "discussion-1",
+  name: "001-001-DI",
+  time: "Wed 8:00am-8:50am",
+  location: "CENTR 220",
+  sectionRef: "FA26:E 00001998",
+  eventPackageIds: ["156420", "157065"],
+};
+
+const course: Course = {
+  id: "FA26:E 00001997",
+  name: "PHYS 002A: Physics-Mechanics",
+  instructor: "Olga Dudko",
+  schedule: "TR 11:00am-12:20pm",
+  description: "Term: FA26",
+  color: "#00629b",
+  lectureSectionRef: "FA26:E 00001997",
+  lectureEventPackageIds: ["156420", "156421"],
+  discussionSections: [discussion],
+  tssPackageUrls: {
+    "156420": "https://tss.ucsd.edu/fiori#package-156420",
+    "156421": "https://tss.ucsd.edu/fiori#package-156421",
+  },
+};
+
+describe("resolveTssBookingUrl", () => {
+  it("returns the event package shared by every selected section", () => {
+    expect(resolveTssBookingUrl(course, discussion)).toBe(
+      "https://tss.ucsd.edu/fiori#package-156420",
+    );
+  });
+
+  it("does not open a different package when the combination is invalid", () => {
+    expect(resolveTssBookingUrl(course, {
+      ...discussion,
+      eventPackageIds: ["157065"],
+    })).toBeUndefined();
+  });
+
+  it("requires a selection for every section type offered by the course", () => {
+    expect(resolveTssBookingUrl(course)).toBeUndefined();
+  });
+
+  it("uses a module route when Class Planner has no event-package route", () => {
+    expect(resolveTssBookingUrl({
+      ...course,
+      discussionSections: [],
+      lectureEventPackageIds: undefined,
+      tssFallbackUrl: "https://tss.ucsd.edu/fiori#module-14433",
+    })).toBe("https://tss.ucsd.edu/fiori#module-14433");
+  });
+
+  it("rejects links outside the official TSS origin", () => {
+    expect(resolveTssBookingUrl({
+      ...course,
+      tssPackageUrls: {
+        "156420": "https://example.com/not-tss",
+      },
+    }, discussion)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Context / Problem

Users cannot open the exact selected section directly in TSS.
TSS requires the matching event package, not only a course code.

## Solution

- Return section references, package memberships, and TSS routes from the catalog API.
- Resolve the package shared by the selected primary, discussion, and lab sections.
- Add a validated `Open in TSS` action that updates with section selection.
- Normalize primary section codes and version the same-tab search cache.

This reuses ingested Class Planner data, requires no live Class Planner request, and accepts only recognized HTTPS `tss.ucsd.edu` routes.

## Testing

- Backend typecheck, lint, and 46 tests
- Frontend lint, 52 tests, and production build
- Browser verified packages `156420` and `156421`, invalid combinations, unsafe routes, cache refresh, and safe new-tab behavior
- Required GitHub CI passed

## Additional Context

- Bug/ticket: N/A
- Design doc: N/A
- Benchmarks: N/A
- Migration: None
- Known limitation: The action remains unavailable when Class Planner does not provide enough package or module-route metadata.
