### PR TITLE
Match all available professor ratings

### DIFF
--- a/.github/workflows/nightly-ingestion.yml
+++ b/.github/workflows/nightly-ingestion.yml
@@ -13,7 +13,7 @@ on:
       professors:
         description: Professor rating refresh mode
         required: true
-        default: auto
+        default: always
         type: choice
         options:
           - auto

--- a/backend/README.md
+++ b/backend/README.md
@@ -109,4 +109,5 @@ The app is exported separately from `src/server.ts` so serverless deployment doe
 
 The GitHub Actions workflow in [`.github/workflows/nightly-ingestion.yml`](../.github/workflows/nightly-ingestion.yml) runs catalog ingestion outside the Vercel request lifecycle.
 It runs nightly at 3:17 AM in `America/Chicago` and also supports manual term and professor-mode inputs.
+Manual dispatches preselect `always` so an operator-requested run refreshes professor ratings by default, while scheduled runs continue using `auto`.
 Configure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` as repository Actions secrets before enabling or dispatching it.

--- a/backend/src/ingestion/enrichCoursesWithRatings.ts
+++ b/backend/src/ingestion/enrichCoursesWithRatings.ts
@@ -317,6 +317,8 @@ async function findProfessor(
   const node = data.search.teachers.edges
     .map(({ node: candidate }) => candidate)
     .find((candidate) =>
+      Number.isFinite(candidate.avgRating) &&
+      candidate.avgRating > 0 &&
       teacherNamesMatch(`${candidate.firstName} ${candidate.lastName}`, teacherName)
     );
 

--- a/backend/src/services/supabaseRepository.ts
+++ b/backend/src/services/supabaseRepository.ts
@@ -205,7 +205,7 @@ export function isExactProfessorMatch(professor: RMP): boolean {
 function toExactRmpDocuments(rows: readonly ProfessorRow[]): RMP[] {
   return rows
     .map(toRmpDocument)
-    .filter(isExactProfessorMatch);
+    .filter((professor) => professor.avgRating > 0 && isExactProfessorMatch(professor));
 }
 
 function toTermDocument(row: TermRow): Term {

--- a/backend/src/utils/normalizeTeacherKey.ts
+++ b/backend/src/utils/normalizeTeacherKey.ts
@@ -8,6 +8,17 @@ export function normalizeTeacherKey(name: string): string {
     .toLowerCase();
 }
 
+const VERIFIED_FULL_NAME_ALIASES = new Set([
+  "chung cheng|chung kuan cheng",
+]);
+
+const VERIFIED_GIVEN_NAME_ALIAS_GROUPS: ReadonlyArray<ReadonlySet<string>> = [
+  new Set(["beth", "elizabeth"]),
+  new Set(["gary", "garrison"]),
+  new Set(["joe", "joseph"]),
+  new Set(["steve", "steven", "stephen"]),
+];
+
 export function teacherNamesMatch(left: string, right: string): boolean {
   const leftName = normalizeTeacherName(left);
   const rightName = normalizeTeacherName(right);
@@ -20,11 +31,23 @@ export function teacherNamesMatch(left: string, right: string): boolean {
     return true;
   }
 
+  if (verifiedFullNameAliasesMatch(leftName, rightName)) {
+    return true;
+  }
+
   const leftTokens = leftName.split(" ");
   const rightTokens = rightName.split(" ");
 
+  const reversedRightTokens = rightTokens.slice().reverse();
   return compatibleTokenSequences(leftTokens, rightTokens) ||
-    compatibleTokenSequences(leftTokens, rightTokens.slice().reverse());
+    compatibleTokenSequences(leftTokens, reversedRightTokens) ||
+    highConfidenceNameVariantsMatch(leftTokens, rightTokens) ||
+    highConfidenceNameVariantsMatch(leftTokens, reversedRightTokens);
+}
+
+function verifiedFullNameAliasesMatch(left: string, right: string): boolean {
+  return VERIFIED_FULL_NAME_ALIASES.has(`${left}|${right}`) ||
+    VERIFIED_FULL_NAME_ALIASES.has(`${right}|${left}`);
 }
 
 function compact(nameKey: string): string {
@@ -65,6 +88,89 @@ function compatibleTokenSequences(left: readonly string[], right: readonly strin
       shorter,
     )
   );
+}
+
+function highConfidenceNameVariantsMatch(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length === 2 && right.length === 2) {
+    const givenNamesMatch = givenNameVariantsMatch(left[0]!, right[0]!);
+    const familyNamesMatch = familyNameVariantsMatch(left[1]!, right[1]!);
+    const hasExactAnchor = left[0] === right[0] || left[1] === right[1];
+    return givenNamesMatch && familyNamesMatch && hasExactAnchor;
+  }
+
+  let shorter: readonly string[];
+  let longer: readonly string[];
+  if (left.length === 2 && right.length >= 3) {
+    shorter = left;
+    longer = right;
+  } else if (right.length === 2 && left.length >= 3) {
+    shorter = right;
+    longer = left;
+  } else {
+    return false;
+  }
+
+  return givenNameVariantsMatch(shorter[0]!, longer[0]!) &&
+    familyNameVariantsMatch(shorter[1]!, longer[1]!) &&
+    (shorter[0] === longer[0] || shorter[1] === longer[1]);
+}
+
+function givenNameVariantsMatch(left: string, right: string): boolean {
+  if (left === right || areVerifiedGivenNameAliases(left, right)) {
+    return true;
+  }
+
+  const shorter = left.length <= right.length ? left : right;
+  const longer = shorter === left ? right : left;
+  return (shorter.length >= 4 && longer.startsWith(shorter)) ||
+    (shorter.length >= 5 && editDistanceAtMostOne(left, right));
+}
+
+function familyNameVariantsMatch(left: string, right: string): boolean {
+  return left === right ||
+    (Math.min(left.length, right.length) >= 5 && editDistanceAtMostOne(left, right));
+}
+
+function areVerifiedGivenNameAliases(left: string, right: string): boolean {
+  return VERIFIED_GIVEN_NAME_ALIAS_GROUPS.some((group) =>
+    group.has(left) && group.has(right)
+  );
+}
+
+function editDistanceAtMostOne(left: string, right: string): boolean {
+  if (Math.abs(left.length - right.length) > 1) {
+    return false;
+  }
+
+  let leftIndex = 0;
+  let rightIndex = 0;
+  let edits = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    if (left[leftIndex] === right[rightIndex]) {
+      leftIndex += 1;
+      rightIndex += 1;
+      continue;
+    }
+
+    edits += 1;
+    if (edits > 1) {
+      return false;
+    }
+
+    if (left.length > right.length) {
+      leftIndex += 1;
+    } else if (right.length > left.length) {
+      rightIndex += 1;
+    } else {
+      leftIndex += 1;
+      rightIndex += 1;
+    }
+  }
+
+  return edits + (leftIndex < left.length || rightIndex < right.length ? 1 : 0) <= 1;
 }
 
 function tokenSequencesMatch(left: readonly string[], right: readonly string[]): boolean {

--- a/backend/src/utils/normalizeTeacherKey.ts
+++ b/backend/src/utils/normalizeTeacherKey.ts
@@ -9,15 +9,16 @@ export function normalizeTeacherKey(name: string): string {
 }
 
 const VERIFIED_FULL_NAME_ALIASES = new Set([
+  "berk ustun|berk usstun",
   "chung cheng|chung kuan cheng",
+  "elizabeth simon|beth simon",
+  "garrison cottrell|gary cottrell",
+  "joe politz|joseph politz",
+  "mia minnes|mia minnes kemp",
+  "ndapandula nakashole|ndapa nakashole",
+  "shlomo dubnov|schlomo dubnov",
+  "steven swanson|steve swanson",
 ]);
-
-const VERIFIED_GIVEN_NAME_ALIAS_GROUPS: ReadonlyArray<ReadonlySet<string>> = [
-  new Set(["beth", "elizabeth"]),
-  new Set(["gary", "garrison"]),
-  new Set(["joe", "joseph"]),
-  new Set(["steve", "steven", "stephen"]),
-];
 
 export function teacherNamesMatch(left: string, right: string): boolean {
   const leftName = normalizeTeacherName(left);
@@ -38,11 +39,8 @@ export function teacherNamesMatch(left: string, right: string): boolean {
   const leftTokens = leftName.split(" ");
   const rightTokens = rightName.split(" ");
 
-  const reversedRightTokens = rightTokens.slice().reverse();
   return compatibleTokenSequences(leftTokens, rightTokens) ||
-    compatibleTokenSequences(leftTokens, reversedRightTokens) ||
-    highConfidenceNameVariantsMatch(leftTokens, rightTokens) ||
-    highConfidenceNameVariantsMatch(leftTokens, reversedRightTokens);
+    compatibleTokenSequences(leftTokens, rightTokens.slice().reverse());
 }
 
 function verifiedFullNameAliasesMatch(left: string, right: string): boolean {
@@ -88,89 +86,6 @@ function compatibleTokenSequences(left: readonly string[], right: readonly strin
       shorter,
     )
   );
-}
-
-function highConfidenceNameVariantsMatch(
-  left: readonly string[],
-  right: readonly string[],
-): boolean {
-  if (left.length === 2 && right.length === 2) {
-    const givenNamesMatch = givenNameVariantsMatch(left[0]!, right[0]!);
-    const familyNamesMatch = familyNameVariantsMatch(left[1]!, right[1]!);
-    const hasExactAnchor = left[0] === right[0] || left[1] === right[1];
-    return givenNamesMatch && familyNamesMatch && hasExactAnchor;
-  }
-
-  let shorter: readonly string[];
-  let longer: readonly string[];
-  if (left.length === 2 && right.length >= 3) {
-    shorter = left;
-    longer = right;
-  } else if (right.length === 2 && left.length >= 3) {
-    shorter = right;
-    longer = left;
-  } else {
-    return false;
-  }
-
-  return givenNameVariantsMatch(shorter[0]!, longer[0]!) &&
-    familyNameVariantsMatch(shorter[1]!, longer[1]!) &&
-    (shorter[0] === longer[0] || shorter[1] === longer[1]);
-}
-
-function givenNameVariantsMatch(left: string, right: string): boolean {
-  if (left === right || areVerifiedGivenNameAliases(left, right)) {
-    return true;
-  }
-
-  const shorter = left.length <= right.length ? left : right;
-  const longer = shorter === left ? right : left;
-  return (shorter.length >= 4 && longer.startsWith(shorter)) ||
-    (shorter.length >= 5 && editDistanceAtMostOne(left, right));
-}
-
-function familyNameVariantsMatch(left: string, right: string): boolean {
-  return left === right ||
-    (Math.min(left.length, right.length) >= 5 && editDistanceAtMostOne(left, right));
-}
-
-function areVerifiedGivenNameAliases(left: string, right: string): boolean {
-  return VERIFIED_GIVEN_NAME_ALIAS_GROUPS.some((group) =>
-    group.has(left) && group.has(right)
-  );
-}
-
-function editDistanceAtMostOne(left: string, right: string): boolean {
-  if (Math.abs(left.length - right.length) > 1) {
-    return false;
-  }
-
-  let leftIndex = 0;
-  let rightIndex = 0;
-  let edits = 0;
-  while (leftIndex < left.length && rightIndex < right.length) {
-    if (left[leftIndex] === right[rightIndex]) {
-      leftIndex += 1;
-      rightIndex += 1;
-      continue;
-    }
-
-    edits += 1;
-    if (edits > 1) {
-      return false;
-    }
-
-    if (left.length > right.length) {
-      leftIndex += 1;
-    } else if (right.length > left.length) {
-      rightIndex += 1;
-    } else {
-      leftIndex += 1;
-      rightIndex += 1;
-    }
-  }
-
-  return edits + (leftIndex < left.length || rightIndex < right.length ? 1 : 0) <= 1;
 }
 
 function tokenSequencesMatch(left: readonly string[], right: readonly string[]): boolean {

--- a/backend/tests/ingestion/enrichCoursesWithRatings.test.ts
+++ b/backend/tests/ingestion/enrichCoursesWithRatings.test.ts
@@ -69,6 +69,16 @@ function professorResponse(...names: string[]) {
   });
 }
 
+type ProfessorResponsePayload = {
+  data: {
+    search: {
+      teachers: {
+        edges: Array<{ node: { avgRating: number } }>;
+      };
+    };
+  };
+};
+
 describe("normalizePercentage", () => {
   it.each([
     [-1, 0],
@@ -201,6 +211,94 @@ describe("enrichCoursesWithRatings", () => {
         profileUrl: "https://www.ratemyprofessors.com/professor/12345",
       }),
     ]);
+  });
+
+  it.each([
+    ["Berk Ustun", "Berk Usstun"],
+    ["Chung Cheng", "Chung-Kuan Cheng"],
+    ["Elizabeth Simon", "Beth Simon"],
+    ["Garrison Cottrell", "Gary Cottrell"],
+    ["Joe Politz", "Joseph Politz"],
+    ["Ndapandula Nakashole", "Ndapa Nakashole"],
+    ["Shlomo Dubnov", "Schlomo Dubnov"],
+    ["Steven Swanson", "Steve Swanson"],
+  ])("matches the verified RMP identity variant %p to %p", async (teacher, candidate) => {
+    const fetcher = jest.fn<RmpFetch>(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      return body.query.includes("SchoolSearch")
+        ? schoolResponse()
+        : professorResponse(candidate);
+    });
+
+    const result = await enrichCoursesWithRatings(
+      [course(teacher)],
+      { fetch: fetcher },
+    );
+
+    expect(result.counts).toMatchObject({ matched: 1, unmatched: 0 });
+    expect(result.professors[0]).toEqual(expect.objectContaining({
+      nameKey: normalizeTeacherKey(teacher),
+    }));
+  });
+
+  it("skips an unrelated fuzzy result before a verified identity variant", async () => {
+    const fetcher = jest.fn<RmpFetch>(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      return body.query.includes("SchoolSearch")
+        ? schoolResponse()
+        : professorResponse("Berk Schneider", "Berk Usstun");
+    });
+
+    const result = await enrichCoursesWithRatings(
+      [course("Berk Ustun")],
+      { fetch: fetcher },
+    );
+
+    expect(result.professors[0]).toEqual(expect.objectContaining({
+      name: "berk usstun",
+      profileUrl: "https://www.ratemyprofessors.com/professor/12346",
+    }));
+  });
+
+  it("prefers a rated surname variant over an unrated duplicate profile", async () => {
+    const fetcher = jest.fn<RmpFetch>(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      if (body.query.includes("SchoolSearch")) return schoolResponse();
+      const result = await professorResponse("Mia Minnes", "Mia Minnes-Kemp").json() as
+        ProfessorResponsePayload;
+      result.data.search.teachers.edges[0].node.avgRating = 0;
+      return response(result);
+    });
+
+    const result = await enrichCoursesWithRatings(
+      [course("Mia Minnes")],
+      { fetch: fetcher },
+    );
+
+    expect(result.professors[0]).toEqual(expect.objectContaining({
+      avgRating: 4.8,
+      name: "mia minnes-kemp",
+      profileUrl: "https://www.ratemyprofessors.com/professor/12346",
+    }));
+  });
+
+  it("does not publish an unrated RMP profile as a zero-star rating", async () => {
+    const fetcher = jest.fn<RmpFetch>(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as { query: string };
+      if (body.query.includes("SchoolSearch")) return schoolResponse();
+      const result = await professorResponse("Melissa Gymrek").json() as
+        ProfessorResponsePayload;
+      result.data.search.teachers.edges[0].node.avgRating = 0;
+      return response(result);
+    });
+
+    const result = await enrichCoursesWithRatings(
+      [course("Melissa Gymrek")],
+      { fetch: fetcher },
+    );
+
+    expect(result.counts).toMatchObject({ matched: 0, unmatched: 1 });
+    expect(result.professors).toEqual([]);
   });
 
   it("keeps the historical key while matching a hyphenated instructor", async () => {

--- a/backend/tests/services/supabaseRepository.test.ts
+++ b/backend/tests/services/supabaseRepository.test.ts
@@ -277,4 +277,14 @@ describe("isExactProfessorMatch", () => {
       takeAgainPercent: 44,
     })).toBe(false);
   });
+
+  it("accepts a verified RMP alias stored under the catalog instructor key", () => {
+    expect(isExactProfessorMatch({
+      avgDiff: 2.1,
+      avgRating: 4.2,
+      name: "Joseph Politz",
+      nameKey: "joe politz",
+      takeAgainPercent: 90,
+    })).toBe(true);
+  });
 });

--- a/backend/tests/utils/normalizeTeacherKey.test.ts
+++ b/backend/tests/utils/normalizeTeacherKey.test.ts
@@ -19,6 +19,16 @@ describe("teacherNamesMatch", () => {
     ["J. Silvio Gutkind", "Silvio Gutkind"],
     ["John A Smith", "John Alan Smith"],
     ["John A Smith", "John Smith"],
+    ["Berk Ustun", "Berk Usstun"],
+    ["Chung Cheng", "Chung-Kuan Cheng"],
+    ["Elizabeth Simon", "Beth Simon"],
+    ["Garrison Cottrell", "Gary Cottrell"],
+    ["Joe Politz", "Joseph Politz"],
+    ["Mia Minnes", "Mia Minnes-Kemp"],
+    ["Ndapandula Nakashole", "Ndapa Nakashole"],
+    ["Shlomo Dubnov", "Schlomo Dubnov"],
+    ["Steven Swanson", "Steve Swanson"],
+    ["Virginia De Sa", "Virginia Desa"],
   ])("accepts equivalent instructor names %p and %p", (left, right) => {
     expect(teacherNamesMatch(left, right)).toBe(true);
   });
@@ -32,6 +42,9 @@ describe("teacherNamesMatch", () => {
     ["John A Smith", "John B Smith"],
     ["John Alan Smith", "John Brian Smith"],
     ["Mayumi Mochizuki McKee", "Mayumi McKee"],
+    ["Aaron Shalev", "Aaron Schulman"],
+    ["Hannah Carter", "Andrea Carter"],
+    ["Tzu Mao Li", "Liam Mueller"],
   ])("rejects different instructors %p and %p", (left, right) => {
     expect(teacherNamesMatch(left, right)).toBe(false);
   });

--- a/backend/tests/utils/normalizeTeacherKey.test.ts
+++ b/backend/tests/utils/normalizeTeacherKey.test.ts
@@ -44,6 +44,9 @@ describe("teacherNamesMatch", () => {
     ["Mayumi Mochizuki McKee", "Mayumi McKee"],
     ["Aaron Shalev", "Aaron Schulman"],
     ["Hannah Carter", "Andrea Carter"],
+    ["John Smith", "John Smyth"],
+    ["John Smith", "Johnny Smith"],
+    ["Mia Minnes", "Mia Minnes-Sanchez"],
     ["Tzu Mao Li", "Liam Mueller"],
   ])("rejects different instructors %p and %p", (left, right) => {
     expect(teacherNamesMatch(left, right)).toBe(false);


### PR DESCRIPTION
## Summary

- Match verified RMP name variants through explicit full-identity pairs.
- Ignore unrated duplicate profiles and stale zero-rating records.
- Default manual catalog ingestion to a forced professor refresh.

## Problem

The catalog and Rate My Professors use different names for several UC San Diego instructors.
Strict comparison correctly blocked unrelated fuzzy results, but it also hid valid ratings for nicknames, shortened names, spelling variants, and compound surnames.
A normal automatic ingestion run could also skip the professor phase, leaving corrected matching logic unapplied.

## Solution

The matcher now supports an explicit set of full-name identity pairs verified against live RMP results and UC San Diego sources.
The existing strict middle-name and conflicting-identity guards remain in place.
Professor enrichment and reads exclude zero-rating profiles so an unrated duplicate cannot outrank the instructor's rated profile.
Manual ingestion preselects `always`, making the operator-triggered rollout refresh ratings without changing nightly scheduling behavior.

## Verification

- Live RMP smoke test: 10 requested, 10 matched, 0 unmatched, 0 failed.
- Verified live profiles include Joe Politz, Mia Minnes, Steven Swanson, Ndapandula Nakashole, Berk Ustun, Chung Cheng, Elizabeth Simon, Garrison Cottrell, Shlomo Dubnov, and Virginia De Sa.
- Backend tests: 95 passed across 11 suites.
- Backend lint: passed.
- Backend TypeScript check: passed.
- Backend build: passed.
- Automated-review follow-up rejects generic near-surname, given-name-prefix, and trailing-surname collisions while retaining the live 10/10 match result.

## Rollout

After merge, manually dispatch `Nightly catalog ingestion` with the preselected `always` professor mode.
The refresh will overwrite stale matches and populate every rating for which RMP returns a verified, rated UC San Diego profile.
Instructors without a rated RMP profile will continue to show the safe search fallback.
