### PR TITLE
Enrich ratings for every displayed instructor

### DIFF
--- a/backend/src/ingestion/enrichCoursesWithRatings.ts
+++ b/backend/src/ingestion/enrichCoursesWithRatings.ts
@@ -121,14 +121,11 @@ export type CourseRatingEnrichment = Readonly<{
   warnings: string[];
 }>;
 
-/** Defines the injectable operation used by professor enrichment. */
-export type EnrichCoursesWithRatingsDependencies = Readonly<{
-  fetch: RmpFetch;
+/** Configures professor enrichment and its injectable fetch operation. */
+export type EnrichCoursesWithRatingsOptions = Readonly<{
+  additionalInstructorNames?: readonly string[];
+  fetch?: RmpFetch;
 }>;
-
-const productionDependencies: EnrichCoursesWithRatingsDependencies = {
-  fetch: globalThis.fetch,
-};
 
 /** Indicates that the professor phase completed no professor requests. */
 export class ProfessorEnrichmentUnavailableError extends Error {
@@ -157,17 +154,22 @@ export function normalizePercentage(value: number | null): number {
  * Existing course ratings are retained for unmatched or failed lookups.
  *
  * @param courses Courses whose instructors should be looked up.
- * @param dependencies Injectable fetch client used by tests.
+ * @param options Additional displayed instructors and an injectable fetch client.
  * @returns Enriched course copies, successful ratings, outcome counts, and warnings.
  * @throws ProfessorEnrichmentUnavailableError when the school lookup fails or no professor request succeeds.
  */
 export async function enrichCoursesWithRatings(
   courses: readonly Course[],
-  dependencies: EnrichCoursesWithRatingsDependencies = productionDependencies,
+  options: EnrichCoursesWithRatingsOptions = {},
 ): Promise<CourseRatingEnrichment> {
   const teachersByKey = new Map<string, string>();
-  for (const { Teacher } of courses) {
-    const teacherName = Teacher.trim();
+  const instructorNames = [
+    ...courses.map(({ Teacher }) => Teacher),
+    ...(options.additionalInstructorNames ?? []),
+  ];
+
+  for (const instructorName of instructorNames) {
+    const teacherName = instructorName.trim();
     const teacherKey = normalizeTeacherKey(teacherName);
     if (teacherKey && !teachersByKey.has(teacherKey)) {
       teachersByKey.set(teacherKey, teacherName);
@@ -189,9 +191,10 @@ export async function enrichCoursesWithRatings(
   }
 
   let schoolId: string;
+  const fetcher = options.fetch ?? globalThis.fetch;
 
   try {
-    schoolId = await findSchoolId(dependencies.fetch);
+    schoolId = await findSchoolId(fetcher);
   } catch (error) {
     throw new ProfessorEnrichmentUnavailableError(
       `Rate My Professors school lookup failed: ${errorMessage(error)}`,
@@ -208,7 +211,7 @@ export async function enrichCoursesWithRatings(
           teacherName,
           teacherKey,
           schoolId,
-          dependencies.fetch,
+          fetcher,
         );
         return { professor, teacherKey } as const;
       } catch (error) {

--- a/backend/src/ingestion/runCatalogIngestion.ts
+++ b/backend/src/ingestion/runCatalogIngestion.ts
@@ -99,7 +99,9 @@ export async function runCatalogIngestion(
 
     if (professorsRequested) {
       try {
-        const enrichment = await dependencies.enrichProfessors(result.courses);
+        const enrichment = await dependencies.enrichProfessors(result.courses, {
+          additionalInstructorNames: catalogInstructorNames(result.catalog),
+        });
         professorCounts = enrichment.counts;
         warnings.push(...enrichment.warnings);
         await dependencies.upsertProfessors(enrichment.professors);
@@ -153,6 +155,15 @@ export async function runCatalogIngestion(
 
     throw error;
   }
+}
+
+function catalogInstructorNames(
+  catalog: ClassPlannerCatalogSnapshot,
+): string[] {
+  return Array.from(new Set([
+    ...catalog.offerings.flatMap(({ instructors }) => instructors),
+    ...catalog.sections.flatMap(({ instructors }) => instructors),
+  ].map((name) => name.trim()).filter(Boolean)));
 }
 
 /** Resolves explicit modes or the automatic Sunday and retry policy. */

--- a/backend/tests/ingestion/enrichCoursesWithRatings.test.ts
+++ b/backend/tests/ingestion/enrichCoursesWithRatings.test.ts
@@ -127,6 +127,37 @@ describe("enrichCoursesWithRatings", () => {
     });
   });
 
+  it("looks up displayed instructors that are not the legacy course teacher", async () => {
+    const fetcher = jest.fn<RmpFetch>(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        variables?: { query?: { text?: string } };
+      };
+      const query = body.variables?.query?.text;
+
+      if (!query || query === "University of California San Diego") {
+        return schoolResponse();
+      }
+
+      return query === "grace hopper"
+        ? professorResponse("Grace Hopper")
+        : professorResponse("Ada Lovelace");
+    });
+
+    const result = await enrichCoursesWithRatings(
+      [course("Ada Lovelace")],
+      {
+        additionalInstructorNames: ["Grace Hopper", "Ada Lovelace", "  "],
+        fetch: fetcher,
+      },
+    );
+
+    expect(result.counts).toMatchObject({ matched: 2, requested: 2 });
+    expect(result.professors.map(({ nameKey }) => nameKey)).toEqual([
+      "ada lovelace",
+      "grace hopper",
+    ]);
+  });
+
   it("selects the exact professor when a fuzzy result is ranked first", async () => {
     const fetcher = jest.fn<RmpFetch>(async (_url, init) => {
       const body = JSON.parse(String(init?.body)) as { query: string };

--- a/backend/tests/ingestion/runCatalogIngestion.test.ts
+++ b/backend/tests/ingestion/runCatalogIngestion.test.ts
@@ -12,7 +12,7 @@ const catalog: ClassPlannerCatalogSnapshot = {
   event_packages: [],
   meetings: [],
   module_routes: [],
-  offerings: [{ source_key: "CSE-101" }] as ClassPlannerCatalogSnapshot["offerings"],
+  offerings: [],
   package_sections: [],
   sections: [],
 };
@@ -85,6 +85,43 @@ describe("runCatalogIngestion", () => {
 
     expect(calls).toEqual(["catalog", "professors"]);
     expect(result.catalogPublished).toBe(true);
+  });
+
+  it("enriches every instructor displayed by offerings and sections", async () => {
+    const enrichProfessors = jest.fn<CatalogIngestionDependencies["enrichProfessors"]>(
+      async (_courses, options) => {
+        expect(options?.additionalInstructorNames).toEqual([
+          "Ada Lovelace",
+          "Grace Hopper",
+          "Barbara Liskov",
+        ]);
+        return dependencies().enrichProfessors(courses);
+      },
+    );
+    const displayedInstructorCatalog: ClassPlannerCatalogSnapshot = {
+      ...catalog,
+      offerings: [{
+        source_key: "CSE-293",
+        instructors: ["Ada Lovelace", "Grace Hopper"],
+      }] as unknown as ClassPlannerCatalogSnapshot["offerings"],
+      sections: [{
+        instructors: ["Barbara Liskov", "Grace Hopper"],
+      }] as unknown as ClassPlannerCatalogSnapshot["sections"],
+    };
+
+    await runCatalogIngestion(
+      { professorMode: "always", trigger: "workflow_dispatch" },
+      dependencies({
+        enrichProfessors,
+        ingest: async () => ({
+          catalog: displayedInstructorCatalog,
+          courses,
+          term: "FA26",
+        }),
+      }),
+    );
+
+    expect(enrichProfessors).toHaveBeenCalledTimes(1);
   });
 
   it("completes with warnings after a partial professor failure", async () => {


### PR DESCRIPTION
Problem

Professor refreshes only looked up the single legacy teacher selected for each course. Course search can also display offering-level and section-level instructors, so hundreds of visible instructors were never sent to Rate My Professors.

Solution

- Include every instructor persisted in catalog offerings and sections in professor enrichment.
- Normalize and deduplicate those names before issuing requests.
- Preserve the existing verified exact-name and alias matching safeguards.
- Add regressions for offering-only and section-only displayed instructors.

Verification

- Production reproduction: 1,995 unique displayable instructor keys versus 1,235 requested by the previous ingestion.
- npm run lint
- npm run typecheck
- npm run build
- npm test -- --runInBand (100 tests passed)